### PR TITLE
Add Next.js App Router EC template with SEO, cart, orders and chat

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals", "next/typescript"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+node_modules
+.next
+out
+.DS_Store
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+.env*

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,0 +1,14 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "images.unsplash.com"
+      }
+    ]
+  }
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "hobby-ec-nextjs",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "15.1.6",
+    "react": "19.0.0",
+    "react-dom": "19.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.7",
+    "@types/react": "^19.0.3",
+    "@types/react-dom": "^19.0.2",
+    "eslint": "^9.17.0",
+    "eslint-config-next": "15.1.6",
+    "typescript": "^5.7.3",
+    "tailwindcss": "^3.4.17",
+    "autoprefixer": "^10.4.20",
+    "postcss": "^8.4.49"
+  }
+}

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/public/downloads/aurora-pack.zip
+++ b/public/downloads/aurora-pack.zip
@@ -1,0 +1,1 @@
+placeholder

--- a/public/downloads/city-night-pack.zip
+++ b/public/downloads/city-night-pack.zip
@@ -1,0 +1,1 @@
+placeholder

--- a/public/downloads/minimal-icons.zip
+++ b/public/downloads/minimal-icons.zip
@@ -1,0 +1,1 @@
+placeholder

--- a/src/actions/cartActions.ts
+++ b/src/actions/cartActions.ts
@@ -1,0 +1,18 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { getCart, setCart } from "@/lib/cart";
+
+export async function addToCart(productId: string) {
+  const cart = await getCart();
+  const existing = cart.items.find((item) => item.productId === productId);
+
+  if (existing) {
+    existing.quantity += 1;
+  } else {
+    cart.items.push({ productId, quantity: 1 });
+  }
+
+  await setCart(cart);
+  revalidatePath("/cart");
+}

--- a/src/actions/orderActions.ts
+++ b/src/actions/orderActions.ts
@@ -1,0 +1,33 @@
+"use server";
+
+import { redirect } from "next/navigation";
+import { clearCart, getCart } from "@/lib/cart";
+import { getProducts } from "@/lib/products";
+import { saveOrder } from "@/lib/orders";
+
+export async function createOrder() {
+  const [cart, products] = await Promise.all([getCart(), getProducts()]);
+
+  if (cart.items.length === 0) {
+    redirect("/cart");
+  }
+
+  const orderId = `ORD-${Date.now()}`;
+  const orderItems = cart.items
+    .map((item) => {
+      const product = products.find((p) => p.id === item.productId);
+      if (!product) {
+        return null;
+      }
+      return {
+        title: product.title,
+        downloadFile: product.downloadFile
+      };
+    })
+    .filter((item): item is { title: string; downloadFile: string } => item !== null);
+
+  await saveOrder({ id: orderId, items: orderItems });
+  await clearCart();
+
+  redirect(`/purchase/success/${orderId}`);
+}

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+import { addMessage, listMessages } from "@/lib/chatStore";
+
+export async function GET() {
+  return NextResponse.json({ messages: listMessages() });
+}
+
+export async function POST(request: Request) {
+  const body = (await request.json()) as { text?: string };
+  const text = String(body.text ?? "").trim();
+
+  if (!text) {
+    return NextResponse.json({ error: "text is required" }, { status: 400 });
+  }
+
+  addMessage("guest", text);
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/stripe/route.ts
+++ b/src/app/api/stripe/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from "next/server";
+
+export async function POST() {
+  return NextResponse.json({
+    message: "学習用テンプレートのため、Stripe連携は未実装です。"
+  });
+}

--- a/src/app/cart/page.tsx
+++ b/src/app/cart/page.tsx
@@ -1,0 +1,55 @@
+import Link from "next/link";
+import { getCart } from "@/lib/cart";
+import { getProducts } from "@/lib/products";
+
+export default async function CartPage() {
+  const [cart, products] = await Promise.all([getCart(), getProducts()]);
+
+  const displayItems = cart.items
+    .map((item) => {
+      const product = products.find((p) => p.id === item.productId);
+      if (!product) {
+        return null;
+      }
+
+      return {
+        id: product.id,
+        title: product.title,
+        quantity: item.quantity,
+        subtotal: product.price * item.quantity
+      };
+    })
+    .filter((item): item is { id: string; title: string; quantity: number; subtotal: number } => item !== null);
+
+  const total = displayItems.reduce((sum, item) => sum + item.subtotal, 0);
+
+  return (
+    <section className="space-y-6">
+      <h1 className="text-3xl font-bold">カート</h1>
+      {displayItems.length === 0 ? (
+        <p>
+          カートに商品がありません。<Link href="/products">商品一覧へ</Link>
+        </p>
+      ) : (
+        <>
+          <ul className="space-y-3 rounded-xl border border-slate-200 bg-white p-4">
+            {displayItems.map((item) => (
+              <li key={item.id} className="flex justify-between text-sm">
+                <span>
+                  {item.title} × {item.quantity}
+                </span>
+                <span>¥{item.subtotal.toLocaleString()}</span>
+              </li>
+            ))}
+          </ul>
+          <p className="text-right text-lg font-bold">合計: ¥{total.toLocaleString()}</p>
+          <div className="text-right">
+            <Link className="rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white" href="/checkout">
+              チェックアウトへ
+            </Link>
+          </div>
+        </>
+      )}
+    </section>
+  );
+}

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -1,0 +1,10 @@
+import ChatWidget from "@/components/ChatWidget";
+
+export default function ChatPage() {
+  return (
+    <section className="space-y-6">
+      <h1 className="text-3xl font-bold">サポートチャット</h1>
+      <ChatWidget />
+    </section>
+  );
+}

--- a/src/app/checkout/page.tsx
+++ b/src/app/checkout/page.tsx
@@ -1,0 +1,15 @@
+import { createOrder } from "@/actions/orderActions";
+
+export default function CheckoutPage() {
+  return (
+    <section className="space-y-6">
+      <h1 className="text-3xl font-bold">チェックアウト</h1>
+      <p className="text-slate-600">デジタル商品のため、購入後すぐにダウンロードリンクが表示されます。</p>
+      <form action={createOrder}>
+        <button className="rounded-md bg-emerald-600 px-4 py-2 text-sm font-semibold text-white hover:bg-emerald-700" type="submit">
+          注文を確定する
+        </button>
+      </form>
+    </section>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,15 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light;
+}
+
+body {
+  @apply bg-slate-50 text-slate-900 antialiased;
+}
+
+a {
+  @apply text-blue-700 hover:text-blue-800;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from "next";
+import "./globals.css";
+import Header from "@/components/layout/Header";
+import { createMetadata } from "@/lib/seo";
+
+export const metadata: Metadata = createMetadata({
+  title: "ホーム",
+  description: "壁紙・写真・アイコンを販売する学習用デジタル素材ECサイト",
+  path: "/",
+  image: "https://example.com/og/home.jpg"
+});
+
+export default function RootLayout({ children }: Readonly<{ children: React.ReactNode }>) {
+  return (
+    <html lang="ja">
+      <body>
+        <Header />
+        <main className="mx-auto w-full max-w-5xl px-4 py-8">{children}</main>
+      </body>
+    </html>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,33 @@
+import Link from "next/link";
+import ProductCard from "@/components/ProductCard";
+import { getProducts } from "@/lib/products";
+
+export default async function HomePage() {
+  const products = await getProducts();
+
+  return (
+    <section className="space-y-8">
+      <div className="rounded-2xl bg-gradient-to-r from-slate-900 to-blue-900 p-8 text-white">
+        <h1 className="text-4xl font-bold">クリエイター向けデジタル素材EC</h1>
+        <p className="mt-3 max-w-3xl text-slate-200">
+          壁紙・写真・アイコンをワンストップで購入できる、Next.js App Router学習用のECテンプレートです。
+        </p>
+        <Link
+          href="/products"
+          className="mt-6 inline-flex rounded-md bg-white px-4 py-2 text-sm font-semibold text-slate-900"
+        >
+          商品を見る
+        </Link>
+      </div>
+
+      <div className="space-y-4">
+        <h2 className="text-2xl font-bold">人気素材</h2>
+        <div className="grid gap-4 md:grid-cols-3">
+          {products.slice(0, 3).map((product) => (
+            <ProductCard key={product.id} product={product} />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/products/[id]/page.tsx
+++ b/src/app/products/[id]/page.tsx
@@ -1,0 +1,64 @@
+import Image from "next/image";
+import { notFound } from "next/navigation";
+import AddToCartButton from "@/components/AddToCartButton";
+import JsonLd from "@/components/JsonLd";
+import { getProductById } from "@/lib/products";
+import { createMetadata } from "@/lib/seo";
+
+export async function generateMetadata({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const product = await getProductById(id);
+
+  if (!product) {
+    return createMetadata({
+      title: "商品が見つかりません",
+      description: "指定された商品は存在しません。",
+      path: `/products/${id}`,
+      image: "https://example.com/og/not-found.jpg"
+    });
+  }
+
+  return createMetadata({
+    title: product.title,
+    description: product.description,
+    path: `/products/${product.id}`,
+    image: product.image
+  });
+}
+
+export default async function ProductDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const product = await getProductById(id);
+
+  if (!product) {
+    notFound();
+  }
+
+  return (
+    <article className="space-y-4">
+      <Image src={product.image} alt={product.title} width={1200} height={675} className="h-80 w-full rounded-xl object-cover" />
+      <h1 className="text-3xl font-bold">{product.title}</h1>
+      <p>{product.description}</p>
+      <p className="text-2xl font-semibold">¥{product.price.toLocaleString()}</p>
+      <AddToCartButton product={product} />
+
+      <JsonLd
+        data={{
+          "@context": "https://schema.org",
+          "@type": "Product",
+          name: product.title,
+          description: product.description,
+          sku: product.id,
+          image: product.image,
+          offers: {
+            "@type": "Offer",
+            priceCurrency: "JPY",
+            price: product.price,
+            availability: "https://schema.org/InStock",
+            url: `https://example.com/products/${product.id}`
+          }
+        }}
+      />
+    </article>
+  );
+}

--- a/src/app/products/layout.tsx
+++ b/src/app/products/layout.tsx
@@ -1,0 +1,3 @@
+export default function ProductsLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/src/app/products/page.tsx
+++ b/src/app/products/page.tsx
@@ -1,0 +1,38 @@
+import JsonLd from "@/components/JsonLd";
+import ProductCard from "@/components/ProductCard";
+import { getProducts } from "@/lib/products";
+import { createMetadata } from "@/lib/seo";
+
+export const metadata = createMetadata({
+  title: "商品一覧",
+  description: "壁紙・写真・アイコンのデジタル素材一覧",
+  path: "/products",
+  image: "https://example.com/og/products.jpg"
+});
+
+export default async function ProductsPage() {
+  const products = await getProducts();
+
+  return (
+    <section className="space-y-6">
+      <h1 className="text-3xl font-bold">商品一覧</h1>
+      <div className="grid gap-4 md:grid-cols-3">
+        {products.map((product) => (
+          <ProductCard key={product.id} product={product} />
+        ))}
+      </div>
+      <JsonLd
+        data={{
+          "@context": "https://schema.org",
+          "@type": "ItemList",
+          itemListElement: products.map((product, index) => ({
+            "@type": "ListItem",
+            position: index + 1,
+            url: `https://example.com/products/${product.id}`,
+            name: product.title
+          }))
+        }}
+      />
+    </section>
+  );
+}

--- a/src/app/purchase/success/[orderId]/page.tsx
+++ b/src/app/purchase/success/[orderId]/page.tsx
@@ -1,0 +1,25 @@
+import { notFound } from "next/navigation";
+import { getOrderById } from "@/lib/orders";
+
+export default async function PurchaseSuccessPage({ params }: { params: Promise<{ orderId: string }> }) {
+  const { orderId } = await params;
+  const order = await getOrderById(orderId);
+
+  if (!order) {
+    notFound();
+  }
+
+  return (
+    <section className="space-y-4">
+      <h1 className="text-3xl font-bold">購入完了</h1>
+      <p className="text-sm text-slate-500">注文番号: {order.id}</p>
+      <ul className="list-disc space-y-2 pl-5">
+        {order.items.map((item) => (
+          <li key={`${item.title}-${item.downloadFile}`}>
+            {item.title}: <a href={item.downloadFile}>ダウンロード</a>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/components/AddToCartButton.tsx
+++ b/src/components/AddToCartButton.tsx
@@ -1,0 +1,13 @@
+import { addToCart } from "@/actions/cartActions";
+import type { Product } from "@/types";
+import Button from "@/components/ui/Button";
+
+export default function AddToCartButton({ product }: { product: Product }) {
+  const action = addToCart.bind(null, product.id);
+
+  return (
+    <form action={action}>
+      <Button type="submit">カートに追加</Button>
+    </form>
+  );
+}

--- a/src/components/ChatWidget.tsx
+++ b/src/components/ChatWidget.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { FormEvent, useEffect, useState } from "react";
+import Button from "@/components/ui/Button";
+
+type Message = {
+  id: number;
+  user: string;
+  text: string;
+  createdAt: string;
+};
+
+export default function ChatWidget() {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [text, setText] = useState("");
+
+  const fetchMessages = async () => {
+    const response = await fetch("/api/chat", { cache: "no-store" });
+    const data = (await response.json()) as { messages: Message[] };
+    setMessages(data.messages);
+  };
+
+  useEffect(() => {
+    fetchMessages();
+    const timer = setInterval(fetchMessages, 3000);
+    return () => clearInterval(timer);
+  }, []);
+
+  const onSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    const trimmed = text.trim();
+    if (!trimmed) {
+      return;
+    }
+
+    await fetch("/api/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text: trimmed })
+    });
+
+    setText("");
+    fetchMessages();
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="max-h-80 space-y-3 overflow-y-auto rounded-xl border border-slate-200 bg-white p-4">
+        {messages.map((message) => (
+          <div key={message.id} className="text-sm">
+            <p className="font-semibold text-slate-700">{message.user}</p>
+            <p>{message.text}</p>
+          </div>
+        ))}
+      </div>
+      <form onSubmit={onSubmit} className="flex gap-2">
+        <input
+          className="flex-1 rounded-md border border-slate-300 px-3 py-2"
+          placeholder="メッセージを入力"
+          value={text}
+          onChange={(event) => setText(event.target.value)}
+        />
+        <Button type="submit">送信</Button>
+      </form>
+    </div>
+  );
+}

--- a/src/components/JsonLd.tsx
+++ b/src/components/JsonLd.tsx
@@ -1,0 +1,8 @@
+export default function JsonLd({ data }: { data: Record<string, unknown> }) {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+    />
+  );
+}

--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -1,0 +1,18 @@
+import Image from "next/image";
+import Link from "next/link";
+import type { Product } from "@/types";
+
+export default function ProductCard({ product }: { product: Product }) {
+  return (
+    <article className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
+      <Image src={product.image} alt={product.title} width={640} height={360} className="h-48 w-full object-cover" />
+      <div className="space-y-2 p-4">
+        <h2 className="text-lg font-semibold">
+          <Link href={`/products/${product.id}`}>{product.title}</Link>
+        </h2>
+        <p className="line-clamp-2 text-sm text-slate-600">{product.description}</p>
+        <p className="text-base font-bold">¥{product.price.toLocaleString()}</p>
+      </div>
+    </article>
+  );
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,0 +1,27 @@
+import Link from "next/link";
+
+const navItems = [
+  { href: "/products", label: "商品一覧" },
+  { href: "/cart", label: "カート" },
+  { href: "/checkout", label: "チェックアウト" },
+  { href: "/chat", label: "チャット" }
+];
+
+export default function Header() {
+  return (
+    <header className="border-b border-slate-200 bg-white/90 backdrop-blur">
+      <div className="mx-auto flex w-full max-w-5xl items-center justify-between px-4 py-3">
+        <Link href="/" className="text-lg font-bold text-slate-900">
+          Digital Assets EC
+        </Link>
+        <nav className="flex items-center gap-4 text-sm">
+          {navItems.map((item) => (
+            <Link key={item.href} href={item.href}>
+              {item.label}
+            </Link>
+          ))}
+        </nav>
+      </div>
+    </header>
+  );
+}

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,0 +1,14 @@
+import type { ButtonHTMLAttributes, PropsWithChildren } from "react";
+
+type Props = PropsWithChildren<ButtonHTMLAttributes<HTMLButtonElement>>;
+
+export default function Button({ children, className = "", ...props }: Props) {
+  return (
+    <button
+      {...props}
+      className={`rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-slate-300 ${className}`}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/lib/cart.ts
+++ b/src/lib/cart.ts
@@ -1,0 +1,63 @@
+import { cookies } from "next/headers";
+import type { Cart } from "@/types";
+
+const CART_COOKIE_KEY = "ec_cart";
+
+function normalizeCart(input: unknown): Cart {
+  if (!input || typeof input !== "object" || !("items" in input)) {
+    return { items: [] };
+  }
+
+  const maybeItems = (input as { items?: unknown }).items;
+  if (!Array.isArray(maybeItems)) {
+    return { items: [] };
+  }
+
+  return {
+    items: maybeItems
+      .map((item) => {
+        if (!item || typeof item !== "object") {
+          return null;
+        }
+
+        const productId = (item as { productId?: unknown }).productId;
+        const quantity = (item as { quantity?: unknown }).quantity;
+
+        if (typeof productId !== "string" || typeof quantity !== "number") {
+          return null;
+        }
+
+        return { productId, quantity: Math.max(1, Math.floor(quantity)) };
+      })
+      .filter((item): item is { productId: string; quantity: number } => item !== null)
+  };
+}
+
+export async function getCart(): Promise<Cart> {
+  const store = await cookies();
+  const raw = store.get(CART_COOKIE_KEY)?.value;
+
+  if (!raw) {
+    return { items: [] };
+  }
+
+  try {
+    return normalizeCart(JSON.parse(raw));
+  } catch {
+    return { items: [] };
+  }
+}
+
+export async function setCart(cart: Cart) {
+  const store = await cookies();
+  store.set(CART_COOKIE_KEY, JSON.stringify(cart), {
+    httpOnly: true,
+    sameSite: "lax",
+    path: "/"
+  });
+}
+
+export async function clearCart() {
+  const store = await cookies();
+  store.delete(CART_COOKIE_KEY);
+}

--- a/src/lib/chatStore.ts
+++ b/src/lib/chatStore.ts
@@ -1,0 +1,28 @@
+type ChatMessage = {
+  id: number;
+  user: string;
+  text: string;
+  createdAt: string;
+};
+
+const messages: ChatMessage[] = [
+  {
+    id: 1,
+    user: "support",
+    text: "いらっしゃいませ！気になる素材があれば質問してください。",
+    createdAt: new Date().toISOString()
+  }
+];
+
+export function addMessage(user: string, text: string) {
+  messages.push({
+    id: messages.length + 1,
+    user,
+    text,
+    createdAt: new Date().toISOString()
+  });
+}
+
+export function listMessages() {
+  return messages.slice(-20);
+}

--- a/src/lib/orders.ts
+++ b/src/lib/orders.ts
@@ -1,0 +1,11 @@
+import type { Order } from "@/types";
+
+const orderStore = new Map<string, Order>();
+
+export async function saveOrder(order: Order) {
+  orderStore.set(order.id, order);
+}
+
+export async function getOrderById(orderId: string) {
+  return orderStore.get(orderId) ?? null;
+}

--- a/src/lib/products.ts
+++ b/src/lib/products.ts
@@ -1,0 +1,39 @@
+import type { Product } from "@/types";
+
+const PRODUCTS: Product[] = [
+  {
+    id: "aurora-wallpaper-4k",
+    title: "Aurora Wallpaper 4K",
+    description: "高解像度のオーロラ壁紙セット（4枚）。",
+    category: "wallpaper",
+    price: 1200,
+    image: "https://images.unsplash.com/photo-1483347756197-71ef80e95f73?auto=format&fit=crop&w=1200&q=80",
+    downloadFile: "/downloads/aurora-pack.zip"
+  },
+  {
+    id: "city-night-photo-pack",
+    title: "City Night Photo Pack",
+    description: "夜景写真10枚の商用利用可能パック。",
+    category: "photo",
+    price: 1800,
+    image: "https://images.unsplash.com/photo-1514565131-fce0801e5785?auto=format&fit=crop&w=1200&q=80",
+    downloadFile: "/downloads/city-night-pack.zip"
+  },
+  {
+    id: "minimal-ui-icon-set",
+    title: "Minimal UI Icon Set",
+    description: "Webとアプリ制作で使えるSVGアイコン300種。",
+    category: "icon",
+    price: 2400,
+    image: "https://images.unsplash.com/photo-1581291518633-83b4ebd1d83e?auto=format&fit=crop&w=1200&q=80",
+    downloadFile: "/downloads/minimal-icons.zip"
+  }
+];
+
+export async function getProducts() {
+  return PRODUCTS;
+}
+
+export async function getProductById(id: string) {
+  return PRODUCTS.find((p) => p.id === id) ?? null;
+}

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,0 +1,32 @@
+import type { Metadata } from "next";
+
+const SITE = "Digital Assets EC";
+const BASE = "https://example.com";
+
+export function createMetadata(input: {
+  title: string;
+  description: string;
+  path: string;
+  image: string;
+}): Metadata {
+  const url = `${BASE}${input.path}`;
+  return {
+    title: `${input.title} | ${SITE}`,
+    description: input.description,
+    alternates: { canonical: url },
+    openGraph: {
+      title: input.title,
+      description: input.description,
+      url,
+      siteName: SITE,
+      images: [{ url: input.image }],
+      type: "website"
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: input.title,
+      description: input.description,
+      images: [input.image]
+    }
+  };
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,30 @@
+export type ProductCategory = "wallpaper" | "photo" | "icon";
+
+export type Product = {
+  id: string;
+  title: string;
+  description: string;
+  category: ProductCategory;
+  price: number;
+  image: string;
+  downloadFile: string;
+};
+
+export type CartItem = {
+  productId: string;
+  quantity: number;
+};
+
+export type Cart = {
+  items: CartItem[];
+};
+
+export type OrderItem = {
+  title: string;
+  downloadFile: string;
+};
+
+export type Order = {
+  id: string;
+  items: OrderItem[];
+};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,15 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: [
+    "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/app/**/*.{js,ts,jsx,tsx,mdx}"
+  ],
+  theme: {
+    extend: {}
+  },
+  plugins: []
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
### Motivation
- Provide a ready-to-run learning scaffold for a digital-assets EC site following Next.js App Router + Server Components and SEO best practices.
- Include minimal end-to-end flows (product list/detail, cart, checkout, purchase success) and a lightweight chat API for demo/learning.
- Keep integrations stubbed (Stripe) and use simple in-memory / cookie-backed stores so the template is easy to run locally.

### Description
- Project scaffold: added `package.json`, `tsconfig.json`, `next.config.ts`, Tailwind/PostCSS configs and global styles (`src/app/globals.css`) to support a TypeScript App Router project and Tailwind utility classes.
- App routes and pages: implemented `src/app/layout.tsx`, `src/app/page.tsx`, product list/detail under `src/app/products`, cart at `src/app/cart`, checkout at `src/app/checkout`, purchase success at `src/app/purchase/success/[orderId]`, and chat UI at `src/app/chat`.
- Domain & server helpers: added `src/lib/products.ts`, `src/lib/cart.ts` (cookie-backed), `src/lib/orders.ts` (in-memory), `src/lib/seo.ts` (metadata helper), and `src/lib/chatStore.ts` for demo messages.
- Components & actions: added reusable UI components (`Button`, `Header`, `ProductCard`, `JsonLd`, `ChatWidget`, `AddToCartButton`), server actions in `src/actions` for cart/order flows, and route handlers `src/app/api/chat/route.ts` and `src/app/api/stripe/route.ts` (Stripe is a placeholder); also added placeholder download files under `public/downloads`.

### Testing
- Attempted dependency install with `npm install`, but fetching dependencies failed due to registry access returning `403` so dependencies were not installed and install did not complete.
- Ran `npm run lint`, which failed because the `next` binary is not available until dependencies are installed (`sh: 1: next: not found`).
- Tried a Playwright-based page screenshot, but the headless Chromium launch crashed (SIGSEGV) in the environment so a runtime screenshot could not be produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698deab1a1a083288f9dfecea6509236)