### PR TITLE
docs: remove reading-order and relationship sections from docs/README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,23 +6,6 @@
 2. **SEO 対策（metadata API・構造化データ・クロール最適化）**
 3. **リアルタイムチャット機能（段階的導入）**
 
-## 読む順番（推奨）
-
-- `docs/basic-designs/00-priority-and-principles.md`
-- `docs/basic-designs/01-folder-structure.md`
-- `docs/basic-designs/02-page-structure.md`
-- `docs/detailed-designs/03-seo-implementation-checklist.md`
-- `docs/proposals/04-chat-roadmap.md`
-- `docs/requirements-definitions/nextjs-ec-requirements-definition-v1.md`
-- `docs/basic-designs/nextjs-ec-basic-design-v1.md`
-- `docs/detailed-designs/nextjs-ec-detailed-design-v1.md`
-
-## 既存ドキュメントとの関係
-
-- Next.js + SEO の統合ガイド: `docs/nextjs-ec-seo-guide.md`
-- AWS 将来構成: `docs/aws-infra-future-plan.md`
-- LocalStack 検証テンプレート: `docs/localstack-aws-serverless-template.md`
-
 ## 公式一次情報（必読）
 
 - App Router: https://nextjs.org/docs/app


### PR DESCRIPTION
### Motivation
- Remove the `読む順番（推奨）` and `既存ドキュメントとの関係` sections from `docs/README.md` to simplify the top-level documentation and follow the requested doc cleanup.

### Description
- Deleted the two sections from `docs/README.md` and committed the change to the repository.

### Testing
- No runtime tests were required for this documentation-only change and `git status --short` indicated a clean working tree after the commit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e1bfe9d148328882030f93d37aa90)