### PR TITLE
商品詳細ページにフリマアプリ風の出品者信頼情報・関連商品・FAQ構造化を追加

### DIFF
--- a/app/(store)/products/[slug]/page.tsx
+++ b/app/(store)/products/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
-import { getCategoryLabel, getProductBySlug, products } from '@/data/products';
+import { ProductCard } from '@/components/ProductCard';
+import { getCategoryLabel, getProductBySlug, getRelatedProducts, products } from '@/data/products';
 import { getCurrentUser } from '@/lib/auth/demo-session';
 import { isGuest } from '@/lib/auth/permissions';
 import { AddToCartButton } from '@/components/product/AddToCartButton';
@@ -41,6 +42,30 @@ export default async function ProductDetailPage({ params }: Props) {
   }
 
   const jsonLd = buildProductJsonLd(product);
+  const relatedProducts = getRelatedProducts(product, 3);
+  const faqJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: [
+      {
+        '@type': 'Question',
+        name: '購入後はどこからダウンロードできますか？',
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: 'マイページの「購入ライブラリ」から期限付きダウンロードURLを発行できます。'
+        }
+      },
+      {
+        '@type': 'Question',
+        name: '商用利用は可能ですか？',
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: `この商品のライセンスは「${product.license}」です。詳細は利用規約ページをご確認ください。`
+        }
+      }
+    ]
+  };
+
   const chatHref = isGuest(user)
     ? `/login?next=${encodeURIComponent(`/products/${product.slug}`)}`
     : `/chat?new=1&productId=${encodeURIComponent(product.id)}`;
@@ -71,6 +96,20 @@ export default async function ProductDetailPage({ params }: Props) {
             <li>タグ: {product.tags.join(' / ')}</li>
             <li>納品方法: 決済後に有効期限付きダウンロードURLを発行</li>
           </ul>
+
+          <section className="seller-summary" aria-label="出品者情報">
+            <h2>出品者情報</h2>
+            <p>
+              <strong>{product.sellerName}</strong>
+            </p>
+            <ul>
+              <li>評価: ★{product.sellerRating.toFixed(1)}</li>
+              <li>販売実績: {product.sellerSalesCount.toLocaleString('ja-JP')}件</li>
+              <li>平均返信時間: 約{product.sellerResponseHours}時間</li>
+              <li>お気に入り登録: {product.favoriteCount.toLocaleString('ja-JP')}件</li>
+            </ul>
+          </section>
+
           <p className="price">¥{product.priceJpy.toLocaleString('ja-JP')}</p>
 
           <div className="cta-row" aria-label="購入アクション">
@@ -82,9 +121,42 @@ export default async function ProductDetailPage({ params }: Props) {
               この商品について相談
             </ButtonLink>
           </div>
+          <div className="detail-links" aria-label="関連ページ">
+            <ButtonLink href="/faq" variant="ghost">
+              購入前によくある質問
+            </ButtonLink>
+            <ButtonLink href="/legal/terms" variant="ghost">
+              利用規約
+            </ButtonLink>
+          </div>
+        </Card>
+
+        <Card>
+          <h2>関連商品</h2>
+          <p className="muted">同カテゴリの人気商品を中心に表示しています。</p>
+          <div className="related-grid">
+            {relatedProducts.map((related) => (
+              <ProductCard key={related.id} product={related} />
+            ))}
+          </div>
+        </Card>
+
+        <Card>
+          <h2>購入前の確認事項</h2>
+          <h3>ダウンロード期限</h3>
+          <p>決済日から30日以内であれば、何度でも再ダウンロードが可能です。</p>
+          <h3>利用範囲</h3>
+          <p>
+            ライセンスの詳細は
+            <ButtonLink href="/legal/terms" variant="ghost" className="inline-link">
+              利用規約
+            </ButtonLink>
+            を必ずご確認ください。
+          </p>
         </Card>
       </Section>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }} />
     </main>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -1466,3 +1466,48 @@ small,
     grid-template-columns: 1fr;
   }
 }
+
+.seller-summary {
+  margin: 0 0 var(--space-5);
+  padding: var(--space-4);
+  border-radius: var(--radius-md);
+  background: #f6f8f4;
+  border: 1px solid var(--color-border);
+}
+
+.seller-summary h2 {
+  margin-top: 0;
+}
+
+.seller-summary p {
+  margin: 0 0 var(--space-2);
+}
+
+.seller-summary ul {
+  margin: 0;
+  padding-left: 1rem;
+  display: grid;
+  gap: 0.2rem;
+}
+
+.detail-links {
+  margin-top: var(--space-3);
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.related-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--space-4);
+}
+
+.muted {
+  color: var(--color-text-muted);
+}
+
+.inline-link {
+  display: inline-flex;
+  margin: 0 0.25rem;
+}

--- a/data/products.ts
+++ b/data/products.ts
@@ -29,6 +29,11 @@ export type Product = {
   specs: ProductSpec[];
   media: ProductMedia[];
   publishedAt: string;
+  sellerName: string;
+  sellerRating: number;
+  sellerSalesCount: number;
+  sellerResponseHours: number;
+  favoriteCount: number;
 };
 
 export type ProductSearchFilters = {
@@ -58,7 +63,12 @@ export const products: Product[] = [
       { key: 'file_count', label: '収録枚数', value: '20' }
     ],
     media: [{ type: 'image', url: '/samples/tokyo-night.jpg', alt: '東京夜景の壁紙サンプル' }],
-    publishedAt: '2026-01-20T09:00:00+09:00'
+    publishedAt: '2026-01-20T09:00:00+09:00',
+    sellerName: 'NightScape Studio',
+    sellerRating: 4.8,
+    sellerSalesCount: 218,
+    sellerResponseHours: 2,
+    favoriteCount: 146
   },
   {
     id: 'prod-002',
@@ -77,7 +87,12 @@ export const products: Product[] = [
       { key: 'file_count', label: '収録点数', value: '80' }
     ],
     media: [{ type: 'image', url: '/samples/nature-photo.jpg', alt: '自然風景写真のサンプル' }],
-    publishedAt: '2026-01-18T09:00:00+09:00'
+    publishedAt: '2026-01-18T09:00:00+09:00',
+    sellerName: 'NorthField Archive',
+    sellerRating: 4.9,
+    sellerSalesCount: 403,
+    sellerResponseHours: 4,
+    favoriteCount: 287
   },
   {
     id: 'prod-003',
@@ -96,7 +111,12 @@ export const products: Product[] = [
       { key: 'resolution', label: 'PNG最大解像度', value: '4096x4096' }
     ],
     media: [{ type: 'image', url: '/samples/flat-illustration.jpg', alt: 'フラットイラストのサンプル' }],
-    publishedAt: '2026-01-15T09:00:00+09:00'
+    publishedAt: '2026-01-15T09:00:00+09:00',
+    sellerName: 'Flatworks Lab',
+    sellerRating: 4.7,
+    sellerSalesCount: 152,
+    sellerResponseHours: 1,
+    favoriteCount: 121
   },
   {
     id: 'prod-004',
@@ -116,7 +136,12 @@ export const products: Product[] = [
       { key: 'sample_rate', label: 'サンプリング周波数', value: '48kHz / 24bit' }
     ],
     media: [{ type: 'audio', url: '/samples/lofi-preview.mp3', alt: 'Lo-fi BGM試聴サンプル' }],
-    publishedAt: '2026-01-10T09:00:00+09:00'
+    publishedAt: '2026-01-10T09:00:00+09:00',
+    sellerName: 'Lunar Beat Works',
+    sellerRating: 4.6,
+    sellerSalesCount: 96,
+    sellerResponseHours: 3,
+    favoriteCount: 83
   }
 ];
 
@@ -194,6 +219,23 @@ export function getCategoryLabel(category: DigitalCategory) {
     default:
       return 'デジタル商品';
   }
+}
+
+export function getRelatedProducts(target: Product, limit = 3) {
+  return products
+    .filter((product) => product.id !== target.id)
+    .sort((a, b) => {
+      if (a.category === target.category && b.category !== target.category) {
+        return -1;
+      }
+
+      if (a.category !== target.category && b.category === target.category) {
+        return 1;
+      }
+
+      return a.publishedAt < b.publishedAt ? 1 : -1;
+    })
+    .slice(0, limit);
 }
 
 export function isDigitalCategory(value: string): value is DigitalCategory {

--- a/lib/seo/jsonld.ts
+++ b/lib/seo/jsonld.ts
@@ -31,7 +31,16 @@ export function buildProductJsonLd(product: Product) {
       priceCurrency: 'JPY',
       price: product.priceJpy,
       availability: 'https://schema.org/InStock',
-      url: productUrl
+      url: productUrl,
+      seller: {
+        '@type': 'Organization',
+        name: product.sellerName
+      }
+    },
+    aggregateRating: {
+      '@type': 'AggregateRating',
+      ratingValue: product.sellerRating,
+      reviewCount: product.sellerSalesCount
     }
   };
 }


### PR DESCRIPTION
### Motivation
- 商品詳細ページに購入判断を支援するフリマアプリ系の要素（出品者の信頼情報、関連商品の導線、FAQ構造化）を追加してコンバージョンとAEO/SEOを強化するため。 
- 既存の静的データ・App Router構成を活かしつつ、外部APIやインフラを追加せずに実装する方針。 

### Description
- `data/products.ts` に `sellerName`/`sellerRating`/`sellerSalesCount`/`sellerResponseHours`/`favoriteCount` を Product 型とサンプルデータに追加し、同カテゴリ優先の `getRelatedProducts` を実装しました（関連商品ソース）。
- `app/(store)/products/[slug]/page.tsx` を更新して出品者情報ブロック（評価・販売実績・平均返信時間・お気に入り数）、関連商品セクション、購入前の確認事項、FAQ の JSON-LD を挿入し、内部導線ボタンを追加しました。
- `lib/seo/jsonld.ts` の Product JSON-LD を拡張して `offers.seller` と `aggregateRating` を含めるようにし、構造化データを強化しました。
- `app/globals.css` に出品者サマリー・関連グリッド・補助リンク用のスタイルを追加しました。
- 変更ファイル（主要）: `app/(store)/products/[slug]/page.tsx`, `data/products.ts`, `lib/seo/jsonld.ts`, `app/globals.css`。

### Testing
- `npm run lint` を実行して ESLint エラーはなく `PASS` でした。
- `npm run build` を実行して本番ビルドは成功し静的ページの生成も完了しており `PASS` でした。
- Playwright を用いて `/products/tokyo-night-wallpaper-pack` を開いてスクリーンショットを取得する確認を行い `PASS` でした。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9d2678848832887d12a1ea7f8c60a)