### PR TITLE
ECS on EC2 最小構成によるデプロイ基盤の追加（single-instance / single-task）

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+node_modules
+.next
+.git
+.github
+infra
+docs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+coverage
+.env
+.env.*
+!.env.example
+localstack

--- a/.github/workflows/deploy-ecs-ec2.yml
+++ b/.github/workflows/deploy-ecs-ec2.yml
@@ -1,0 +1,63 @@
+name: Deploy ECS on EC2
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  AWS_REGION: ${{ vars.AWS_REGION }}
+  ECS_CLUSTER: ${{ vars.ECS_CLUSTER_NAME }}
+  ECS_SERVICE: ${{ vars.ECS_SERVICE_NAME }}
+  ECR_REPOSITORY: ${{ vars.ECR_REPOSITORY_NAME }}
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build app
+        run: npm run build
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build and push image
+        env:
+          REGISTRY: ${{ steps.ecr.outputs.registry }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker build -t "$REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" -t "$REGISTRY/$ECR_REPOSITORY:latest" .
+          docker push "$REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+          docker push "$REGISTRY/$ECR_REPOSITORY:latest"
+
+      - name: Force new ECS deployment
+        run: |
+          aws ecs update-service \
+            --cluster "$ECS_CLUSTER" \
+            --service "$ECS_SERVICE" \
+            --force-new-deployment
+          aws ecs wait services-stable \
+            --cluster "$ECS_CLUSTER" \
+            --services "$ECS_SERVICE"

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,14 +7,17 @@ FROM node:22-alpine AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
+RUN mkdir -p public
 RUN npm run build
 
 FROM node:22-alpine AS runner
 WORKDIR /app
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
+RUN addgroup -S nodejs && adduser -S nextjs -G nodejs
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/.next/standalone ./
 COPY --from=builder /app/.next/static ./.next/static
+USER nextjs
 EXPOSE 3000
 CMD ["node", "server.js"]

--- a/README.md
+++ b/README.md
@@ -1,72 +1,132 @@
 # Digital Creator Market (Next.js)
 
-壁紙・写真・図やイラスト・デジタル音楽を販売する、Next.js App Router ベースのデジタル商品ECです。
+壁紙・写真・図やイラスト・デジタル音楽を販売する、Next.js App Router ベースのデジタル商品ECです。  
+本リポジトリの本番デプロイ前提は **ECS on EC2（single-instance / single-task）** です。
 
-## 実装済み
+## 現在の本番構成（最小実用）
 
-- **Next.js 最新設計**: App Router / Server Components / Metadata API / Route Handlers
-- **SEO最適化**:
-  - サイト全体の metadata（title/description/keywords/OGP/canonical）
-  - 商品一覧 + 商品詳細の JSON-LD（`ItemList` / `Product`）
-  - 商品詳細ページごとの `generateMetadata`
-- **リアルタイムチャット**: SSE (`/api/chat/stream`) + 送信API (`/api/chat/send`) + 履歴API (`/api/chat/history`) + クライアントウィジェット
-- **AWS最小コスト方針**: standalone 出力を使った単一コンテナ前提（Lightsail Containers 小構成を想定）
+- ECS on EC2
+- ECS Cluster: 1
+- EC2 Instance: 1（ECS container instance）
+- ECS Service: 1
+- ECS Task: 1
+- ECR: 1
+- CloudWatch Logs
+- ALB なし（EC2 側公開）
 
-## ローカル起動（Node.js）
+> chat は **single-instance 前提** です。multi-instance 対応（状態外部化）は本スコープ外です。
+
+## Next.js / SEO / Chat 方針
+
+- Next.js App Router + `output: "standalone"` を継続
+- SEO を損なわない（metadata / JSON-LD / robots / sitemap 維持）
+- chat の現状 API / SSE 動作を壊さない
+
+## Docker 運用
+
+- `Dockerfile` は standalone 生成物で起動します
+- `public` が存在しない場合でも build 失敗しないよう `mkdir -p public` を実行
+- ヘルスチェックエンドポイント: `GET /api/health`
+
+## 環境変数方針（build-time と runtime）
+
+- `NEXT_PUBLIC_*` は原則 build-time 値
+- server-only 値は ECS タスク runtime 注入を優先
+- 機密値は Docker build args に渡さない
+- 機密値は task definition `secrets` で注入し、`environment` へ直書きしない
+
+## SSM / Secrets Manager の責務表
+
+| 保存先 | 例 | 取り扱い |
+|---|---|---|
+| Secrets Manager | `DATABASE_URL`, `JWT_SECRET`, `SESSION_SECRET`, OAuth secret, API secret, webhook secret, private key, password/token | 漏洩時に重大事故へ直結する値 |
+| SSM Parameter Store | `APP_ENV`, `AWS_REGION`, `SITE_URL`, `LOG_LEVEL`, `CHAT_STORAGE_MODE`, 各種 table/bucket/queue 名 | 非機密の環境依存設定 |
+
+## 初回デプロイ手順（Terraform apply）
 
 ```bash
-npm install
-npm run dev
+cp infra/terraform/terraform.tfvars.example infra/terraform/terraform.tfvars
+cd infra/terraform
+terraform init
+terraform fmt -recursive
+terraform validate
+terraform plan -var-file=terraform.tfvars
+terraform apply -var-file=terraform.tfvars
 ```
 
-`http://localhost:3000`
+Terraform 出力で以下を取得します。
 
-## Node.js / npm 運用方針（LTS固定 + パッチ追随）
+- `ci_role_arn`
+- `ecs_cluster_name`
+- `ecs_service_name`
+- `ecr_repository_url`
+- `ecs_instance_public_ip`
 
-- Node.js は **22系 LTS** に固定（`.nvmrc` を唯一の基準とする）。
-- npm は Node 同梱版を原則利用（`packageManager: npm@10` / `engines` で許容範囲を明示）。
-- lockfile は `package-lock.json` を正として、依存更新は PR で差分レビューする。
+## GitHub Actions デプロイ
 
-### セットアップ
+`.github/workflows/deploy-ecs-ec2.yml` が以下を実行します。
+
+1. app build
+2. Docker image build
+3. ECR push（`latest` と `sha`）
+4. ECS service `force-new-deployment`
+
+### GitHub Secrets
+
+- `AWS_CI_ROLE_ARN`
+
+### GitHub Variables
+
+- `AWS_REGION`
+- `ECS_CLUSTER_NAME`
+- `ECS_SERVICE_NAME`
+- `ECR_REPOSITORY_NAME`（Terraform の ECR リポジトリ名）
+
+## 起動・停止・ログ・ロールバック
+
+### 起動
 
 ```bash
-nvm use
+aws ecs update-service --cluster <cluster> --service <service> --desired-count 1
+```
+
+### 停止（コスト削減）
+
+```bash
+aws ecs update-service --cluster <cluster> --service <service> --desired-count 0
+aws ec2 stop-instances --instance-ids <instance-id>
+```
+
+### ログ確認
+
+```bash
+aws logs tail /ecs/<project>-<env> --follow
+```
+
+### ロールバック
+
+```bash
+# 直前のタスク定義リビジョンへ戻して再デプロイ
+aws ecs update-service --cluster <cluster> --service <service> --task-definition <family:revision>
+```
+
+## single-instance 制約
+
+- max=1 前提（自動スケーリング無効）
+- EC2 障害時はサービス停止
+- chat の水平分散は未対応
+- Blue/Green / ALB / Route53 / ACM / Fargate は本スコープ外
+
+## ローカル開発
+
+```bash
 npm ci
 npm run dev
 ```
 
-## CI / Docker での固定
-
-- CI は `.github/workflows/ci.yml` で `.nvmrc` を読み込み、`check-latest: true` で 22 系最新パッチを利用します。
-- Docker はベースイメージに `node:22-*`（本番は `*-slim` 推奨）を指定し、ビルド/実行で同一メジャーを利用してください。
-
-## Docker で最短起動
+または:
 
 ```bash
 cp .env.example .env
 docker compose -f docker-compose.local.yml up --build
 ```
-
-- 開発構成（推奨）: `docker-compose.local.yml`（web + postgres + localstack）
-- 本番近似確認: `docker-compose.yml`（production build/start）
-
-詳細手順・トラブルシュートは `docs/local-development/README.md` を参照してください。
-
-## 追加ドキュメント
-
-- ローカル開発手順（推奨 + 本番近似 + トラブルシュート）: `docs/local-development/README.md`
-- Codex Environment Setup Script 運用: `docs/codex/ENV_SETUP.md`
-- 将来AWS構成（Mermaid/テキスト図）: `docs/future-aws-architecture/README.md`
-
-## CI（GitHub Actions）
-
-`main` 向けの `push` / `pull_request` では CI を必ず実行し、`npm ci` → `lint`（存在時のみ）→ `build`（必須）→ `test`（存在時のみ）を検証します。
-ローカル検証はコンテナでの再現性確認、マージ可否は CI の結果を基準に運用する想定です。
-
-## AWS 低コストデプロイ案
-
-1. Dockerイメージを ECR へ push
-2. **Lightsail Containers** の最小プランで公開
-3. 需要増加時のみ App Runner / ECS Fargate へ移行
-
-> メモ: チャットは DynamoDB + SQS を標準構成とし、`CHAT_STORAGE_MODE=memory` でローカル簡易動作にフォールバックできます。

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  return NextResponse.json({
+    status: 'ok',
+    uptime: process.uptime(),
+    timestamp: new Date().toISOString()
+  });
+}

--- a/docs/aws/ecs-ec2-gap-analysis.md
+++ b/docs/aws/ecs-ec2-gap-analysis.md
@@ -1,0 +1,73 @@
+# ECS on EC2 移行前調査（実装前）
+
+## 1. 現在のデプロイ方式との差分
+
+### 現在
+- README は **Lightsail Containers 想定** の低コスト案を主軸に記載。
+- Terraform は **単体EC2 + SSM デプロイ**（ECS/ECR 非採用）。
+- デプロイスクリプトは EC2 で `docker compose up -d --build` を直接実行する方式。
+
+### 今回の採用先
+- ECS on EC2（single-instance / single-task）
+- ECR へイメージ保存
+- ECS Service で 1 タスクを維持
+- CloudWatch Logs 出力
+- ALB なし（EC2 の public IP から直接公開）
+
+### 差分要点
+- `docker compose` デプロイから、**ECR + ECS Service 更新**へ切り替える。
+- Terraform 管理対象を EC2 単体から、ECS クラスタ・タスク定義・サービス・IAM へ拡張する。
+- 機密情報注入を `environment` 直書きから、**ECS task definition の `secrets`** に寄せる。
+
+## 2. 実コードから抽出した環境変数一覧
+
+抽出元: `process.env` 参照 + `.env.example`。
+
+| 変数名 | 用途（現状） |
+|---|---|
+| NODE_ENV | 実行モード判定 |
+| NEXT_PUBLIC_SITE_ORIGIN | canonical / metadata origin |
+| AWS_REGION | AWS SDK リージョン |
+| AWS_ENDPOINT_URL | LocalStack endpoint |
+| LOCAL_S3_BUCKET | LocalStack health check |
+| LOCAL_SQS_QUEUE_NAME | LocalStack health check |
+| CHAT_CONVERSATIONS_TABLE | chat store設定 |
+| CHAT_MESSAGES_TABLE | chat store設定 |
+| CHAT_USER_QUEUE_TABLE | chat queue table |
+| CHAT_USER_QUEUE_PREFIX | chat queue prefix |
+| CHAT_STORAGE_MODE | chat storage backend モード |
+| DATABASE_URL | DB 接続文字列 |
+
+## 3. 環境変数分類表（今回方針）
+
+| 分類 | 変数 | 理由 |
+|---|---|---|
+| Secrets Manager | `DATABASE_URL` | 漏洩時に重大事故へ直結する接続情報 |
+| Secrets Manager | `JWT_SECRET` / `SESSION_SECRET` / OAuth secret / API secret / webhook secret / private key / password/token 類 | 方針で機密情報は Secrets Manager 管理 |
+| SSM Parameter Store | `APP_ENV` / `AWS_REGION` / `SITE_URL` / `LOG_LEVEL` / `CHAT_STORAGE_MODE` | 非機密の実行時構成値 |
+| SSM Parameter Store | `CHAT_CONVERSATIONS_TABLE` / `CHAT_MESSAGES_TABLE` / `CHAT_USER_QUEUE_TABLE` / `CHAT_USER_QUEUE_PREFIX` | 非機密の AWS リソース名 |
+| build-time 値 | `NEXT_PUBLIC_SITE_ORIGIN`（必要なら） | `NEXT_PUBLIC_*` は build-time 固定が原則 |
+| runtime 値 | `NODE_ENV` / `APP_ENV` / `AWS_REGION` / chat系テーブル名 | server-only 値は runtime 注入優先 |
+
+> 注: `AWS_ENDPOINT_URL` / `LOCAL_*` はローカル向け値のため、本番 ECS では原則未使用。
+
+## 4. single-instance 前提で問題になる箇所
+
+- chat は in-memory / 単一プロセス前提の箇所があり、**multi-instance で整合性が崩れる**可能性がある。
+- ALB なしのため、ヘルス監視は ECS タスクの `healthCheck` と `/api/health` へ依存。
+- EC2 停止中はサービス完全停止（常時可用性は担保しない）。
+- ローリング更新時も desired=1 のため、短時間の切替影響が出る可能性がある。
+
+## 5. 修正対象一覧
+
+- アプリ
+  - `Dockerfile`: standalone 実行最適化 + public 欠如時の build/コピー失敗回避
+  - `.dockerignore`: ビルドコンテキスト最小化
+  - `app/api/health/route.ts`: ECS health check 用 endpoint
+- インフラ
+  - `infra/terraform/*`: ECS on EC2 最小構成へ再定義（ECR/ECS/EC2/IAM/Logs/SG/SSM/Secrets）
+- CI/CD
+  - `.github/workflows/*`: app build / Docker build / ECR push / ECS service 更新
+- ドキュメント
+  - `README.md`: ECS on EC2 手順へ更新
+  - 必要に応じて `docs/aws/*`: 初回デプロイ・起動停止・ログ・ロールバック

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -13,35 +13,78 @@ data "aws_subnets" "default" {
   }
 }
 
-data "aws_ami" "amazon_linux_2023" {
-  most_recent = true
-  owners      = ["amazon"]
-
-  filter {
-    name   = "name"
-    values = ["al2023-ami-2023.*-x86_64"]
-  }
-
-  filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
+data "aws_ssm_parameter" "ecs_optimized_ami" {
+  name = "/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id"
 }
 
 locals {
-  name_prefix = "${var.project_name}-${var.env}"
-  tags = {
-    Name    = "${local.name_prefix}-web"
-    Env     = var.env
-    Role    = "web"
-    Project = var.project_name
+  name_prefix    = "${var.project_name}-${var.env}"
+  cluster_name   = "${local.name_prefix}-cluster"
+  service_name   = "${local.name_prefix}-service"
+  task_family    = "${local.name_prefix}-task"
+  ecr_repo_name  = "${local.name_prefix}-app"
+  log_group_name = "/ecs/${local.name_prefix}"
+  github_subject = "repo:${var.github_owner}/${var.github_repo}:ref:refs/heads/${var.github_branch}"
+
+  ssm_parameter_arns = {
+    for key, value in aws_ssm_parameter.app :
+    key => value.arn
   }
 
-  github_subject = "repo:${var.github_owner}/${var.github_repo}:ref:refs/heads/${var.github_branch}"
+  secret_arns = {
+    for key, value in aws_secretsmanager_secret.app :
+    key => value.arn
+  }
+
+  common_tags = {
+    Project = var.project_name
+    Env     = var.env
+  }
 }
 
-resource "aws_iam_role" "ec2" {
-  name = "${local.name_prefix}-ec2-role"
+resource "aws_cloudwatch_log_group" "ecs" {
+  name              = local.log_group_name
+  retention_in_days = 14
+  tags              = local.common_tags
+}
+
+resource "aws_ecr_repository" "app" {
+  name                 = local.ecr_repo_name
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = local.common_tags
+}
+
+resource "aws_ssm_parameter" "app" {
+  for_each = var.ssm_parameters
+
+  name  = "/${var.project_name}/${var.env}/${each.key}"
+  type  = "String"
+  value = each.value
+  tags  = local.common_tags
+}
+
+resource "aws_secretsmanager_secret" "app" {
+  for_each = var.secrets_manager_values
+
+  name                    = "${var.project_name}/${var.env}/${lower(each.key)}"
+  recovery_window_in_days = 0
+  tags                    = local.common_tags
+}
+
+resource "aws_secretsmanager_secret_version" "app" {
+  for_each = var.secrets_manager_values
+
+  secret_id     = aws_secretsmanager_secret.app[each.key].id
+  secret_string = each.value
+}
+
+resource "aws_iam_role" "ecs_instance" {
+  name = "${local.name_prefix}-ecs-instance-role"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17",
@@ -54,49 +97,35 @@ resource "aws_iam_role" "ec2" {
     }]
   })
 
-  tags = local.tags
+  tags = local.common_tags
 }
 
-resource "aws_iam_role_policy_attachment" "ec2_ssm_core" {
-  role       = aws_iam_role.ec2.name
+resource "aws_iam_role_policy_attachment" "ecs_instance_ecs" {
+  role       = aws_iam_role.ecs_instance.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_instance_ssm" {
+  role       = aws_iam_role.ecs_instance.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
 }
 
-resource "aws_iam_instance_profile" "ec2" {
-  name = "${local.name_prefix}-ec2-profile"
-  role = aws_iam_role.ec2.name
+resource "aws_iam_instance_profile" "ecs" {
+  name = "${local.name_prefix}-ecs-instance-profile"
+  role = aws_iam_role.ecs_instance.name
 }
 
-resource "aws_security_group" "web" {
-  name        = "${local.name_prefix}-web-sg"
-  description = "Web + optional SSH access"
+resource "aws_security_group" "ecs_instance" {
+  name        = "${local.name_prefix}-ecs-instance-sg"
+  description = "Direct ingress to ECS EC2 instance"
   vpc_id      = data.aws_vpc.default.id
 
   ingress {
-    description = "HTTP"
-    from_port   = 80
-    to_port     = 80
+    description = "App Port"
+    from_port   = var.container_port
+    to_port     = var.container_port
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  ingress {
-    description = "HTTPS"
-    from_port   = 443
-    to_port     = 443
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  dynamic "ingress" {
-    for_each = var.allow_ssh ? [1] : []
-    content {
-      description = "SSH"
-      from_port   = 22
-      to_port     = 22
-      protocol    = "tcp"
-      cidr_blocks = [var.ssh_cidr]
-    }
+    cidr_blocks = var.public_ingress_cidrs
   }
 
   egress {
@@ -106,35 +135,219 @@ resource "aws_security_group" "web" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags = local.tags
+  tags = local.common_tags
 }
 
-resource "aws_instance" "web" {
-  ami                    = data.aws_ami.amazon_linux_2023.id
+resource "aws_ecs_cluster" "main" {
+  name = local.cluster_name
+
+  setting {
+    name  = "containerInsights"
+    value = "disabled"
+  }
+
+  tags = local.common_tags
+}
+
+resource "aws_instance" "ecs" {
+  ami                    = data.aws_ssm_parameter.ecs_optimized_ami.value
   instance_type          = var.instance_type
   subnet_id              = data.aws_subnets.default.ids[0]
-  vpc_security_group_ids = [aws_security_group.web.id]
-  iam_instance_profile   = aws_iam_instance_profile.ec2.name
+  vpc_security_group_ids = [aws_security_group.ecs_instance.id]
+  iam_instance_profile   = aws_iam_instance_profile.ecs.name
 
   user_data = <<-EOT
     #!/bin/bash
     set -euxo pipefail
-    mkdir -p /opt/app
-    chown ec2-user:ec2-user /opt/app
+    echo ECS_CLUSTER=${aws_ecs_cluster.main.name} >> /etc/ecs/ecs.config
   EOT
 
-  tags = local.tags
+  tags = merge(local.common_tags, {
+    Name = "${local.name_prefix}-ecs-instance"
+    Role = "ecs"
+  })
+}
+
+resource "aws_iam_role" "task_execution" {
+  name = "${local.name_prefix}-ecs-task-execution-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [{
+      Effect = "Allow",
+      Principal = {
+        Service = "ecs-tasks.amazonaws.com"
+      },
+      Action = "sts:AssumeRole"
+    }]
+  })
+
+  tags = local.common_tags
+}
+
+resource "aws_iam_role_policy_attachment" "task_execution_base" {
+  role       = aws_iam_role.task_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_role_policy" "task_execution_runtime" {
+  name = "${local.name_prefix}-task-runtime-access"
+  role = aws_iam_role.task_execution.id
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = ["ssm:GetParameters", "ssm:GetParameter"],
+        Resource = values(local.ssm_parameter_arns)
+      },
+      {
+        Effect = "Allow",
+        Action = ["secretsmanager:GetSecretValue"],
+        Resource = values(local.secret_arns)
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role" "task" {
+  name = "${local.name_prefix}-ecs-task-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [{
+      Effect = "Allow",
+      Principal = {
+        Service = "ecs-tasks.amazonaws.com"
+      },
+      Action = "sts:AssumeRole"
+    }]
+  })
+
+  tags = local.common_tags
+}
+
+resource "aws_ecs_task_definition" "app" {
+  family                   = local.task_family
+  network_mode             = "bridge"
+  requires_compatibilities = ["EC2"]
+  cpu                      = "256"
+  memory                   = "512"
+  execution_role_arn       = aws_iam_role.task_execution.arn
+  task_role_arn            = aws_iam_role.task.arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "app"
+      image     = "${aws_ecr_repository.app.repository_url}:latest"
+      essential = true
+      portMappings = [
+        {
+          containerPort = var.container_port
+          hostPort      = var.container_port
+          protocol      = "tcp"
+        }
+      ]
+      environment = [
+        {
+          name  = "NODE_ENV"
+          value = "production"
+        },
+        {
+          name  = "APP_ENV"
+          value = aws_ssm_parameter.app["APP_ENV"].value
+        },
+        {
+          name  = "AWS_REGION"
+          value = aws_ssm_parameter.app["AWS_REGION"].value
+        },
+        {
+          name  = "SITE_URL"
+          value = aws_ssm_parameter.app["SITE_URL"].value
+        },
+        {
+          name  = "CHAT_STORAGE_MODE"
+          value = aws_ssm_parameter.app["CHAT_STORAGE_MODE"].value
+        },
+        {
+          name  = "CHAT_CONVERSATIONS_TABLE"
+          value = aws_ssm_parameter.app["CHAT_CONVERSATIONS_TABLE"].value
+        },
+        {
+          name  = "CHAT_MESSAGES_TABLE"
+          value = aws_ssm_parameter.app["CHAT_MESSAGES_TABLE"].value
+        },
+        {
+          name  = "CHAT_USER_QUEUE_TABLE"
+          value = aws_ssm_parameter.app["CHAT_USER_QUEUE_TABLE"].value
+        },
+        {
+          name  = "CHAT_USER_QUEUE_PREFIX"
+          value = aws_ssm_parameter.app["CHAT_USER_QUEUE_PREFIX"].value
+        },
+        {
+          name  = "LOG_LEVEL"
+          value = aws_ssm_parameter.app["LOG_LEVEL"].value
+        }
+      ]
+      secrets = [
+        {
+          name      = "DATABASE_URL"
+          valueFrom = aws_secretsmanager_secret.app["DATABASE_URL"].arn
+        },
+        {
+          name      = "JWT_SECRET"
+          valueFrom = aws_secretsmanager_secret.app["JWT_SECRET"].arn
+        },
+        {
+          name      = "SESSION_SECRET"
+          valueFrom = aws_secretsmanager_secret.app["SESSION_SECRET"].arn
+        }
+      ]
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = aws_cloudwatch_log_group.ecs.name
+          awslogs-region        = var.aws_region
+          awslogs-stream-prefix = "app"
+        }
+      }
+      healthCheck = {
+        command     = ["CMD-SHELL", "wget --spider -q http://localhost:${var.container_port}/api/health || exit 1"]
+        interval    = 30
+        timeout     = 5
+        retries     = 3
+        startPeriod = 30
+      }
+    }
+  ])
+
+  tags = local.common_tags
+}
+
+resource "aws_ecs_service" "app" {
+  name            = local.service_name
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.app.arn
+  desired_count   = 1
+  launch_type     = "EC2"
+
+  deployment_minimum_healthy_percent = 0
+  deployment_maximum_percent         = 100
+
+  depends_on = [
+    aws_instance.ecs
+  ]
+
+  tags = local.common_tags
 }
 
 resource "aws_iam_openid_connect_provider" "github" {
   url             = "https://token.actions.githubusercontent.com"
   client_id_list  = ["sts.amazonaws.com"]
   thumbprint_list = var.github_thumbprints
-
-  tags = {
-    Project = var.project_name
-    Env     = var.env
-  }
+  tags            = local.common_tags
 }
 
 resource "aws_iam_role" "ci" {
@@ -157,10 +370,7 @@ resource "aws_iam_role" "ci" {
     }]
   })
 
-  tags = {
-    Project = var.project_name
-    Env     = var.env
-  }
+  tags = local.common_tags
 }
 
 resource "aws_iam_role_policy" "ci_inline" {
@@ -171,86 +381,38 @@ resource "aws_iam_role_policy" "ci_inline" {
     Version = "2012-10-17",
     Statement = [
       {
-        Sid    = "TerraformEc2Sg",
+        Sid    = "EcrPush",
         Effect = "Allow",
         Action = [
-          "ec2:RunInstances",
-          "ec2:TerminateInstances",
-          "ec2:StartInstances",
-          "ec2:StopInstances",
-          "ec2:CreateTags",
-          "ec2:DeleteTags",
-          "ec2:CreateSecurityGroup",
-          "ec2:DeleteSecurityGroup",
-          "ec2:AuthorizeSecurityGroupIngress",
-          "ec2:RevokeSecurityGroupIngress",
-          "ec2:AuthorizeSecurityGroupEgress",
-          "ec2:RevokeSecurityGroupEgress",
-          "ec2:Describe*"
+          "ecr:GetAuthorizationToken",
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:CompleteLayerUpload",
+          "ecr:InitiateLayerUpload",
+          "ecr:PutImage",
+          "ecr:UploadLayerPart",
+          "ecr:BatchGetImage"
         ],
         Resource = "*"
       },
       {
-        Sid    = "TerraformIamForProject",
+        Sid    = "EcsUpdateService",
         Effect = "Allow",
         Action = [
-          "iam:CreateRole",
-          "iam:DeleteRole",
-          "iam:UpdateAssumeRolePolicy",
-          "iam:CreatePolicy",
-          "iam:DeletePolicy",
-          "iam:CreatePolicyVersion",
-          "iam:DeletePolicyVersion",
-          "iam:SetDefaultPolicyVersion",
-          "iam:PutRolePolicy",
-          "iam:DeleteRolePolicy",
-          "iam:AttachRolePolicy",
-          "iam:DetachRolePolicy",
-          "iam:CreateInstanceProfile",
-          "iam:DeleteInstanceProfile",
-          "iam:AddRoleToInstanceProfile",
-          "iam:RemoveRoleFromInstanceProfile",
-          "iam:TagRole",
-          "iam:GetRole",
-          "iam:GetPolicy",
-          "iam:GetPolicyVersion",
-          "iam:List*"
+          "ecs:UpdateService",
+          "ecs:DescribeServices",
+          "ecs:DescribeTaskDefinition",
+          "ecs:RegisterTaskDefinition"
         ],
-        Resource = [
-          "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.name_prefix}-*",
-          "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/${local.name_prefix}-*",
-          "arn:aws:iam::${data.aws_caller_identity.current.account_id}:instance-profile/${local.name_prefix}-*"
-        ]
+        Resource = "*"
       },
       {
-        Sid    = "TerraformOidcProvider",
-        Effect = "Allow",
-        Action = [
-          "iam:CreateOpenIDConnectProvider",
-          "iam:DeleteOpenIDConnectProvider",
-          "iam:UpdateOpenIDConnectProviderThumbprint",
-          "iam:TagOpenIDConnectProvider",
-          "iam:GetOpenIDConnectProvider",
-          "iam:ListOpenIDConnectProviders"
-        ],
-        Resource = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/token.actions.githubusercontent.com"
-      },
-      {
-        Sid    = "PassOnlyEc2Role",
+        Sid    = "IamPassRoleForTaskDefs",
         Effect = "Allow",
         Action = ["iam:PassRole"],
-        Resource = aws_iam_role.ec2.arn
-      },
-      {
-        Sid    = "SsmDeploy",
-        Effect = "Allow",
-        Action = [
-          "ssm:SendCommand",
-          "ssm:GetCommandInvocation",
-          "ssm:ListCommandInvocations",
-          "ec2:DescribeInstances"
-        ],
-        Resource = "*"
+        Resource = [
+          aws_iam_role.task_execution.arn,
+          aws_iam_role.task.arn
+        ]
       }
     ]
   })

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -1,19 +1,24 @@
-output "ec2_instance_id" {
-  description = "Web EC2 instance ID"
-  value       = aws_instance.web.id
-}
-
-output "ec2_public_ip" {
-  description = "Web EC2 public IP"
-  value       = aws_instance.web.public_ip
-}
-
 output "ci_role_arn" {
   description = "GitHub Actions OIDC role ARN"
   value       = aws_iam_role.ci.arn
 }
 
-output "ec2_role_arn" {
-  description = "EC2 IAM role ARN"
-  value       = aws_iam_role.ec2.arn
+output "ecs_cluster_name" {
+  description = "ECS cluster name"
+  value       = aws_ecs_cluster.main.name
+}
+
+output "ecs_service_name" {
+  description = "ECS service name"
+  value       = aws_ecs_service.app.name
+}
+
+output "ecr_repository_url" {
+  description = "ECR repository URL"
+  value       = aws_ecr_repository.app.repository_url
+}
+
+output "ecs_instance_public_ip" {
+  description = "ECS EC2 instance public IP"
+  value       = aws_instance.ecs.public_ip
 }

--- a/infra/terraform/terraform.tfvars.example
+++ b/infra/terraform/terraform.tfvars.example
@@ -1,10 +1,30 @@
-aws_region         = "ap-northeast-1"
-project_name       = "hobby-ec"
-env                = "prod"
-instance_type      = "t3.small"
-allow_ssh          = false
-ssh_cidr           = "203.0.113.10/32"
+aws_region    = "ap-northeast-1"
+project_name  = "hobby-ec"
+env           = "prod"
+instance_type = "t3.small"
+
 github_owner       = "your-github-owner"
 github_repo        = "hobby-ec-nextJS"
 github_branch      = "main"
 github_thumbprints = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
+
+container_port       = 3000
+public_ingress_cidrs = ["0.0.0.0/0"]
+
+ssm_parameters = {
+  APP_ENV                 = "prod"
+  AWS_REGION              = "ap-northeast-1"
+  SITE_URL                = "https://example.com"
+  LOG_LEVEL               = "info"
+  CHAT_STORAGE_MODE       = "aws"
+  CHAT_CONVERSATIONS_TABLE = "ChatConversations"
+  CHAT_MESSAGES_TABLE     = "ChatMessages"
+  CHAT_USER_QUEUE_TABLE   = "ChatUserQueue"
+  CHAT_USER_QUEUE_PREFIX  = "chat-user"
+}
+
+secrets_manager_values = {
+  DATABASE_URL   = "postgresql://user:pass@host:5432/dbname"
+  JWT_SECRET     = "replace-me"
+  SESSION_SECRET = "replace-me"
+}

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -4,7 +4,7 @@ variable "aws_region" {
 }
 
 variable "project_name" {
-  description = "Project name used in tags and IAM role names"
+  description = "Project name used in resource names"
   type        = string
 }
 
@@ -12,29 +12,12 @@ variable "env" {
   description = "Deployment environment"
   type        = string
   default     = "prod"
-
-  validation {
-    condition     = var.env == "prod"
-    error_message = "This Terraform stack only supports env=prod."
-  }
 }
 
 variable "instance_type" {
-  description = "EC2 instance type"
+  description = "ECS container instance type"
   type        = string
   default     = "t3.small"
-}
-
-variable "allow_ssh" {
-  description = "Allow inbound SSH when true"
-  type        = bool
-  default     = false
-}
-
-variable "ssh_cidr" {
-  description = "Allowed CIDR for SSH when allow_ssh=true"
-  type        = string
-  default     = "0.0.0.0/32"
 }
 
 variable "github_owner" {
@@ -56,4 +39,43 @@ variable "github_branch" {
 variable "github_thumbprints" {
   description = "GitHub OIDC root CA thumbprints"
   type        = list(string)
+}
+
+variable "container_port" {
+  description = "Application container port"
+  type        = number
+  default     = 3000
+}
+
+variable "public_ingress_cidrs" {
+  description = "Allowed CIDRs for inbound app traffic"
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
+variable "ssm_parameters" {
+  description = "Non-secret runtime configuration values stored in SSM Parameter Store"
+  type        = map(string)
+  default = {
+    APP_ENV                = "prod"
+    AWS_REGION             = "ap-northeast-1"
+    SITE_URL               = "http://localhost:3000"
+    LOG_LEVEL              = "info"
+    CHAT_STORAGE_MODE      = "aws"
+    CHAT_CONVERSATIONS_TABLE = "ChatConversations"
+    CHAT_MESSAGES_TABLE    = "ChatMessages"
+    CHAT_USER_QUEUE_TABLE  = "ChatUserQueue"
+    CHAT_USER_QUEUE_PREFIX = "chat-user"
+  }
+}
+
+variable "secrets_manager_values" {
+  description = "Secret runtime values stored in AWS Secrets Manager"
+  type        = map(string)
+  sensitive   = true
+  default = {
+    DATABASE_URL   = ""
+    JWT_SECRET     = ""
+    SESSION_SECRET = ""
+  }
 }


### PR DESCRIPTION
### 1) 実装・修正内容
- Terraform を ECS on EC2 の最小構成へ再構成し、ECR / ECS Cluster / EC2 (container instance) / ECS TaskDefinition / ECS Service / CloudWatch Logs / IAM / Security Group / SSM Parameter / Secrets Manager / GitHub OIDC Role を追加しました。
- Next.js アプリにヘルスチェック用の Route Handler を追加し、`GET /api/health` でステータスを返すようにしました（ECS タスクの healthCheck 先として利用）。
- `Dockerfile` を standalone 出力向けに見直し、`public` が存在しない場合でもビルドが失敗しないよう `mkdir -p public` を追加し、非 root ユーザーでの実行に変更しました。
- `.dockerignore` を追加し、ビルドコンテキストを最小化しました。
- GitHub Actions ワークフローを追加し、`build -> docker build -> ECR push -> ECS service force-new-deployment` を自動化しました（`.github/workflows/deploy-ecs-ec2.yml`）。
- README を ECS on EC2 前提の運用手順に更新し、初回デプロイ手順／起動・停止・ログ確認・ロールバック・SSM/Secrets 責務表／single-instance 制約を明記しました。
- 実装前調査（既存デプロイ差分、環境変数抽出・分類、single-instance の懸念、修正対象）を `docs/aws/ecs-ec2-gap-analysis.md` に追加しました。

### 2) 実装理由
- Next.js 最新設計整合性: App Router + `output: 'standalone'` を維持し、Route Handler でヘルスエンドポイントを実装することで Next.js の設計原則を損なわないためです（方針1）。
- SEO 保全: SEO / AEO に関わる実装（metadata, JSON-LD, sitemap 等）は変更せず、デプロイ基盤を切り替えるだけに留めて SEO 影響を最小化しました（方針2）。
- chat の現状維持: chat は single-instance 前提の実装のままとし、マルチインスタンス化に伴う状態外部化は今回スコープ外としました（方針3）。
- コスト最適化: ALB や Fargate を使わず EC2 直公開 + single-instance/single-task 固定で初期コストを抑える構成を採用しました（方針4）。
- 選定除外理由: Fargate / ALB / multi-instance は可用性や運用性の向上につながるが今回の「個人プロジェクト向け最小実装」要件とコスト制約のため見送りました。

### 3) 変更ファイル
- `infra/terraform/main.tf` — ECS on EC2 最小構成（ECR/ECS/EC2/TaskDef/Service/Logs/ IAM/SG/SSM/Secrets）を定義しました。 
- `infra/terraform/variables.tf` — コンテナポート・SSM/Secrets の入力変数を追加しました。
- `infra/terraform/terraform.tfvars.example` — サンプル値を追加しました（SSM/Secrets の例含む）。
- `infra/terraform/outputs.tf` — `ci_role_arn` / `ecs_cluster_name` / `ecs_service_name` / `ecr_repository_url` / `ecs_instance_public_ip` を出力に追加しました。
- `Dockerfile` — standalone 実行向けに `public` 作成を入れ、非 root 実行に変更しました。
- `.dockerignore` — ビルドコンテキスト最小化。
- `app/api/health/route.ts` — ECS ヘルスチェック用エンドポイントを追加しました。
- `.github/workflows/deploy-ecs-ec2.yml` — build -> ECR push -> ECS 更新の自動デプロイワークフローを追加しました。
- `README.md` — ECS on EC2 前提の運用手順へ更新しました。
- `docs/aws/ecs-ec2-gap-analysis.md` — 実装前調査レポートを追加しました。

### 4) 動作確認
- 自動テスト / ビルド実行結果（ローカル実行で確認）:
```bash
PASS: npm ci
PASS: npm run lint
PASS: npx tsc --noEmit
PASS: npm run build
FAIL: terraform fmt -recursive  # 実行環境に terraform バイナリが未導入のため実行不可
```
- 手動確認: `npm run build` の出力で `app/api/health` がビルド済みルーティング一覧に含まれることを確認済み（ECS 側 healthCheck の対象として利用可能）。

### 5) 影響範囲（必須4項目）
- Next.js 最新設計への整合性: 整合（`output: 'standalone'` と Route Handler を維持）。
- SEO 影響: なし（SEO に関するソースは変更していません）。
- リアルタイムチャット機能への影響: 原則なし（chat 実装は変更せず、single-instance 制約を明文化）。
- AWS コスト影響: わずかな増加（ECS/ECR 管理分）があるが ALB 非採用・単一インスタンス固定のため最小化しています。

### 6) 提案・懸念点
- Secrets を現状 Terraform 変数で投入する設計になっているため、Terraform state の保護（S3 backend + KMS + state access 制限）を次フェーズで必須化してください。 
- 将来的には ALB + ACM + Route53 へ移行することで TLS / ドメイン管理と可用性を改善できますが、固定費が増えます。移行計画を検討してください。 
- `SITE_URL` / `NEXT_PUBLIC_SITE_ORIGIN` の build/runtime の整合ルールを運用手順に明文化すると事故を減らせます。

### 7) リスクとロールバック
- 想定リスク
  - single-instance 構成のため EC2 障害時にサービス全停止となる点。
  - `desired_count=1` のためデプロイ時に短時間の切替影響（瞬断）が発生する可能性。
  - Secrets を state に含める運用は state 漏洩リスクがある（state 保護が未整備の場合）。
- ロールバック方法
  - 直前のタスク定義リビジョンへ戻して `aws ecs update-service --cluster <cluster> --service <service> --task-definition <family:revision>` を実行して復旧してください。 
  - 必要に応じて `desired-count` を 0 にして停止し、旧イメージを `latest` に差し替えて再デプロイする運用も可能です。

以上、最小構成による ECS on EC2 デプロイ基盤の追加（single-instance / single-task）となります。レビュー時は Terraform の `plan` / `apply` を実行する CI 環境（またはローカルで `terraform` を導入した環境）で `validate` をご確認ください。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b77fb75a988328bab7586aef6907c7)