### PR TITLE
AI Optimization 向けに SEO/AEO 基盤と構造化データを整理

### DIFF
--- a/app/(store)/categories/[category]/page.tsx
+++ b/app/(store)/categories/[category]/page.tsx
@@ -21,7 +21,7 @@ export async function generateStaticParams() {
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { category } = await params;
   if (!isDigitalCategory(category)) {
-    return { title: 'カテゴリが見つかりません' };
+    return { title: 'カテゴリが見つかりません', robots: { index: false, follow: false } };
   }
 
   return buildCategoryMetadata(category);
@@ -46,8 +46,10 @@ export default async function CategoryPage({ params }: Props) {
           { name: categoryLabel, path: `/categories/${category}` }
         ]}
       />
-      <h1>{categoryLabel}</h1>
-      <p>カテゴリ特化ページとして、検索意図に合う商品をまとめています。</p>
+      <h1>{categoryLabel}一覧</h1>
+      <p className="section-description">
+        {categoryLabel}を用途・形式・ライセンスで比較しやすいように、公開商品をまとめています。
+      </p>
       <section className="grid" aria-label="カテゴリ商品一覧">
         {items.map((product) => (
           <ProductCard key={product.id} product={product} />

--- a/app/(store)/contact/page.tsx
+++ b/app/(store)/contact/page.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import { ContactForm } from '@/components/contact/ContactForm';
 import { buildContactMetadata } from '@/lib/seo/metadata';
 
@@ -8,9 +9,24 @@ export default function ContactPage() {
     <main>
       <h1>お問い合わせ</h1>
       <p className="section-description">
-        注文、商品仕様、アカウント設定などのお問い合わせを受け付けています。必要に応じてチャットもご利用ください。
+        注文、商品仕様、ライセンス、アカウント設定に関する問い合わせを受け付けています。送信前にFAQとヘルプを確認すると、回答を早く確認できます。
       </p>
+
+      <section className="hub-grid" aria-label="事前確認の案内">
+        <article className="hub-card">
+          <h2>購入前の質問</h2>
+          <p>ライセンス、支払い方法、利用シーンは FAQ で確認できます。</p>
+          <Link href="/faq">FAQを見る</Link>
+        </article>
+        <article className="hub-card">
+          <h2>規約と法定表記</h2>
+          <p>返品条件や法定情報は Legal ページで確認できます。</p>
+          <Link href="/legal/terms">利用規約を見る</Link>
+        </article>
+      </section>
+
       <section className="settings-card" aria-label="お問い合わせフォーム">
+        <h2>お問い合わせフォーム</h2>
         <ContactForm />
       </section>
     </main>

--- a/app/(store)/faq/page.tsx
+++ b/app/(store)/faq/page.tsx
@@ -1,50 +1,55 @@
 import Link from 'next/link';
 import { buildFaqMetadata } from '@/lib/seo/metadata';
+import { buildFaqJsonLd } from '@/lib/seo/jsonld';
 
 export const metadata = buildFaqMetadata();
 
-const faqs = [
-  {
-    question: '購入後はすぐにダウンロードできますか？',
-    answer: '決済完了後にマイページの購入済みライブラリから即時ダウンロードできます。'
-  },
-  {
-    question: '商用利用は可能ですか？',
-    answer: '商品ごとのライセンス条件に従って商用利用できます。詳細は商品ページをご確認ください。'
-  },
-  {
-    question: '支払い方法は何がありますか？',
-    answer: '現在はクレジットカード決済に対応しています。'
-  },
-  {
-    question: '返品・キャンセルはできますか？',
-    answer: 'デジタル商品の性質上、購入確定後の返品・キャンセルは原則お受けしていません。'
-  }
-];
+const faqs = {
+  beforePurchase: [
+    {
+      question: '商用利用は可能ですか？',
+      answer: '商品ごとのライセンス条件に従って商用利用できます。詳細は商品ページをご確認ください。'
+    },
+    {
+      question: '支払い方法は何がありますか？',
+      answer: '現在はクレジットカード決済に対応しています。'
+    }
+  ],
+  afterPurchase: [
+    {
+      question: '購入後はすぐにダウンロードできますか？',
+      answer: '決済完了後にマイページの購入済みライブラリから即時ダウンロードできます。'
+    },
+    {
+      question: '返品・キャンセルはできますか？',
+      answer: 'デジタル商品の性質上、購入確定後の返品・キャンセルは原則お受けしていません。'
+    }
+  ]
+};
 
 export default function FaqPage() {
-  const faqJsonLd = {
-    '@context': 'https://schema.org',
-    '@type': 'FAQPage',
-    mainEntity: faqs.map((faq) => ({
-      '@type': 'Question',
-      name: faq.question,
-      acceptedAnswer: {
-        '@type': 'Answer',
-        text: faq.answer
-      }
-    }))
-  };
+  const faqJsonLd = buildFaqJsonLd([...faqs.beforePurchase, ...faqs.afterPurchase]);
 
   return (
     <main>
-      <h1>よくある質問（FAQ）</h1>
-      <p className="section-description">購入前後によくお問い合わせいただく内容をまとめています。</p>
+      <h1>よくある質問</h1>
+      <p className="section-description">購入前後によくある質問を、テーマごとに短く整理しています。</p>
 
-      <section className="faq-list" aria-label="よくある質問一覧">
-        {faqs.map((faq) => (
+      <section className="faq-list" aria-label="購入前の質問">
+        <h2>購入前の確認</h2>
+        {faqs.beforePurchase.map((faq) => (
           <article key={faq.question} className="faq-item">
-            <h2>{faq.question}</h2>
+            <h3>{faq.question}</h3>
+            <p>{faq.answer}</p>
+          </article>
+        ))}
+      </section>
+
+      <section className="faq-list" aria-label="購入後の質問">
+        <h2>購入後の確認</h2>
+        {faqs.afterPurchase.map((faq) => (
+          <article key={faq.question} className="faq-item">
+            <h3>{faq.question}</h3>
             <p>{faq.answer}</p>
           </article>
         ))}

--- a/app/(store)/help/page.tsx
+++ b/app/(store)/help/page.tsx
@@ -5,29 +5,29 @@ export const metadata = buildHelpMetadata();
 
 const helpLinks = [
   {
-    title: '注文について',
-    description: '注文履歴・注文詳細・決済状況の確認方法を案内します。',
-    href: '/mypage/orders'
+    title: '商品の選び方',
+    description: 'カテゴリ、タグ、価格帯から用途に合う商品を探す方法です。',
+    href: '/products'
   },
   {
-    title: '配送・ダウンロードについて',
-    description: 'デジタル商品のダウンロード手順や再取得方法を確認できます。',
-    href: '/mypage/library'
+    title: 'ライセンス確認',
+    description: '商用利用や再配布可否を商品ページのライセンス表記で確認できます。',
+    href: '/faq'
   },
   {
-    title: '支払いについて',
-    description: '利用可能な支払い方法と請求タイミングを案内します。',
+    title: '支払いと提供時期',
+    description: '決済方法、請求タイミング、ダウンロード提供時期を確認できます。',
     href: '/legal/tokushoho'
   },
   {
-    title: '返品・キャンセルについて',
-    description: '返品ポリシーおよび問い合わせ前の確認事項をまとめています。',
+    title: '返品・キャンセル',
+    description: 'デジタル商品の返品条件と利用規約を確認できます。',
     href: '/legal/terms'
   },
   {
-    title: 'アカウントについて',
-    description: 'プロフィール・通知・セキュリティ設定の変更手順です。',
-    href: '/mypage/settings'
+    title: '個人情報と問い合わせ',
+    description: '個人情報の取り扱いと問い合わせ窓口の案内です。',
+    href: '/contact'
   }
 ];
 
@@ -35,7 +35,7 @@ export default function HelpPage() {
   return (
     <main>
       <h1>ヘルプセンター</h1>
-      <p className="section-description">カテゴリ別にサポート情報へアクセスできます。</p>
+      <p className="section-description">購入前後に必要な情報を、公開ページ単位で確認できるよう整理しています。</p>
       <section className="hub-grid" aria-label="ヘルプ導線">
         {helpLinks.map((link) => (
           <article key={link.title} className="hub-card">

--- a/app/(store)/legal/LegalPageTemplate.tsx
+++ b/app/(store)/legal/LegalPageTemplate.tsx
@@ -13,16 +13,16 @@ export function LegalPageTemplate({ title, lead, sections }: LegalPageTemplatePr
   return (
     <main>
       <h1>{title}</h1>
-      <p>{lead}</p>
+      <p className="section-description">{lead}</p>
 
-      <dl className="legal-list">
+      <section aria-label={`${title}の本文`}>
         {sections.map((item) => (
-          <div key={item.label} className="legal-item">
-            <dt>{item.label}</dt>
-            <dd>{item.value}</dd>
-          </div>
+          <article key={item.label} className="legal-item">
+            <h2>{item.label}</h2>
+            <p>{item.value}</p>
+          </article>
         ))}
-      </dl>
+      </section>
     </main>
   );
 }

--- a/app/(store)/products/[slug]/page.tsx
+++ b/app/(store)/products/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
-import { getCategoryLabel, getProductBySlug, products } from '@/data/products';
+import { getCategoryLabel, getProductBySlug, products, type Product } from '@/data/products';
 import { getCurrentUser } from '@/lib/auth/demo-session';
 import { isGuest } from '@/lib/auth/permissions';
 import { AddToCartButton } from '@/components/product/AddToCartButton';
@@ -15,6 +15,66 @@ import { Section } from '@/components/ui/Section';
 type Props = {
   params: Promise<{ slug: string }>;
 };
+
+type ProductGuideSection = {
+  title: string;
+  items: string[];
+};
+
+function buildAudienceText(product: Product) {
+  switch (product.category) {
+    case 'wallpaper':
+      return 'PCやタブレットの画面を高解像度で整えたい方に向いています。';
+    case 'photo':
+      return 'Web制作・広告・資料で自然風景写真を使いたい方に向いています。';
+    case 'illustration':
+      return 'LPやサービスサイトで使いやすいイラストをまとめて導入したい方に向いています。';
+    case 'music':
+      return '動画制作や配信で使えるBGMをまとめて用意したい方に向いています。';
+    default:
+      return '用途が明確なデジタル素材を探している方に向いています。';
+  }
+}
+
+function buildUseCaseText(product: Product) {
+  return `主な利用シーン: ${product.tags.join(' / ')}。`;
+}
+
+function buildProductGuideSections(product: Product): ProductGuideSection[] {
+  return [
+    {
+      title: 'この商品は何か',
+      items: [product.description, `${getCategoryLabel(product.category)}カテゴリの商品です。`]
+    },
+    {
+      title: '誰向けか',
+      items: [buildAudienceText(product)]
+    },
+    {
+      title: '利用シーン',
+      items: [buildUseCaseText(product)]
+    },
+    {
+      title: '形式',
+      items: [
+        `ファイル形式は ${product.fileFormat} です。`,
+        `ダウンロード容量は ${product.downloadSizeMB.toLocaleString('ja-JP')}MB です。`
+      ]
+    },
+    {
+      title: 'ライセンス',
+      items: [`適用ライセンスは ${product.license} です。`]
+    },
+    {
+      title: '入手方法',
+      items: ['決済完了後に、有効期限付きのダウンロードURLを発行します。']
+    },
+    {
+      title: '注意事項',
+      items: ['購入前にファイル形式、容量、ライセンス条件をご確認ください。']
+    }
+  ];
+}
 
 export async function generateStaticParams() {
   return products.map((product) => ({ slug: product.slug }));
@@ -41,6 +101,7 @@ export default async function ProductDetailPage({ params }: Props) {
   }
 
   const jsonLd = buildProductJsonLd(product);
+  const productGuideSections = buildProductGuideSections(product);
   const chatHref = isGuest(user)
     ? `/login?next=${encodeURIComponent(`/products/${product.slug}`)}`
     : `/chat?new=1&productId=${encodeURIComponent(product.id)}`;
@@ -51,6 +112,10 @@ export default async function ProductDetailPage({ params }: Props) {
         items={[
           { name: 'ホーム', path: '/' },
           { name: '商品一覧', path: '/products' },
+          {
+            name: getCategoryLabel(product.category),
+            path: `/categories/${product.category}`
+          },
           { name: product.name, path: `/products/${product.slug}` }
         ]}
       />
@@ -83,6 +148,19 @@ export default async function ProductDetailPage({ params }: Props) {
             </ButtonLink>
           </div>
         </Card>
+
+        <section aria-label="商品要約">
+          {productGuideSections.map((section) => (
+            <Card key={section.title}>
+              <h2>{section.title}</h2>
+              <ul className="specs" aria-label={section.title}>
+                {section.items.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+            </Card>
+          ))}
+        </section>
       </Section>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
     </main>

--- a/app/(store)/products/page.tsx
+++ b/app/(store)/products/page.tsx
@@ -27,6 +27,10 @@ function buildProductsCanonical(params: Record<string, string | string[] | undef
   return query.toString() ? `/products?${query.toString()}` : '/products';
 }
 
+function hasIndexableFilters(params: Record<string, string | string[] | undefined>) {
+  return Object.values(params).every((value) => value == null || value === '');
+}
+
 function parseFilters(params: Record<string, string | string[] | undefined>): ProductSearchFilters {
   const priceMinRaw = readValue(params.priceMin);
   const priceMaxRaw = readValue(params.priceMax);
@@ -45,7 +49,10 @@ export async function generateMetadata({ searchParams }: Props): Promise<Metadat
   const params = await searchParams;
   const canonical = buildProductsCanonical(params);
 
-  return buildProductListingMetadata(canonical);
+  return buildProductListingMetadata({
+    canonicalPath: canonical,
+    isIndexable: hasIndexableFilters(params)
+  });
 }
 
 export default async function ProductsPage({ searchParams }: Props) {
@@ -71,7 +78,10 @@ export default async function ProductsPage({ searchParams }: Props) {
 
         <div className="products-content">
           <header className="products-toolbar">
-            <p className="products-count">Products ({items.length})</p>
+            <div>
+              <h1>商品一覧</h1>
+              <p className="products-count">公開商品数: {items.length}件</p>
+            </div>
             <ProductSort sort={filters.sort ?? 'newest'} />
           </header>
 

--- a/app/(store)/search/page.tsx
+++ b/app/(store)/search/page.tsx
@@ -23,10 +23,8 @@ function buildSearchCanonical(params: Record<string, string | string[] | undefin
   return `/search?${query.toString()}`;
 }
 
-export async function generateMetadata({ searchParams }: Props): Promise<Metadata> {
-  const params = await searchParams;
-
-  return buildSearchMetadata(buildSearchCanonical(params));
+export async function generateMetadata(): Promise<Metadata> {
+  return buildSearchMetadata();
 }
 
 export default async function SearchPage({ searchParams }: Props) {

--- a/app/(store)/tags/[tag]/page.tsx
+++ b/app/(store)/tags/[tag]/page.tsx
@@ -1,8 +1,9 @@
 import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
 import { ProductCard } from '@/components/ProductCard';
 import { Breadcrumbs } from '@/components/seo/Breadcrumbs';
 import { getProductsByTag } from '@/data/products';
-import { buildTagMetadata } from '@/lib/seo/metadata';
+import { buildTagMetadata, buildNoIndexRobots } from '@/lib/seo/metadata';
 
 type Props = {
   params: Promise<{ tag: string }>;
@@ -10,12 +11,26 @@ type Props = {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { tag } = await params;
+  const items = getProductsByTag(tag);
+
+  if (items.length === 0) {
+    return {
+      title: 'タグが見つかりません',
+      robots: buildNoIndexRobots(false)
+    };
+  }
+
   return buildTagMetadata(tag);
 }
 
 export default async function TagPage({ params }: Props) {
   const { tag } = await params;
   const items = getProductsByTag(tag);
+
+  if (items.length === 0) {
+    notFound();
+  }
+
   const canonical = `/tags/${encodeURIComponent(tag)}`;
 
   return (
@@ -23,12 +38,14 @@ export default async function TagPage({ params }: Props) {
       <Breadcrumbs
         items={[
           { name: 'ホーム', path: '/' },
-          { name: '商品一覧', path: '/products' },
+          { name: 'タグ一覧', path: '/tags' },
           { name: tag, path: canonical }
         ]}
       />
-      <h1>タグ: {tag}</h1>
-      <p>ニーズ軸で商品を比較できます。</p>
+      <h1>{tag}タグの商品一覧</h1>
+      <p className="section-description">
+        {tag}に関連する商品を、用途と形式が分かる状態でまとめています。
+      </p>
       <section className="grid" aria-label="タグ商品一覧">
         {items.map((product) => (
           <ProductCard key={product.id} product={product} />

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,29 +1,12 @@
-import type { Metadata } from 'next';
 import { SkipLink } from '@/components/a11y/SkipLink';
 import { SiteFooter } from '@/components/layout/SiteFooter';
 import { SiteHeader } from '@/components/layout/SiteHeader';
 import { getCurrentUser } from '@/lib/auth/demo-session';
-import { SITE_ORIGIN } from '@/lib/seo/metadata';
+import { buildRootMetadata } from '@/lib/seo/metadata';
+import { buildOrganizationJsonLd } from '@/lib/seo/jsonld';
 import './globals.css';
 
-export const metadata: Metadata = {
-  metadataBase: new URL(SITE_ORIGIN),
-  title: {
-    default: 'Digital Creator Market',
-    template: '%s | Digital Creator Market'
-  },
-  description:
-    '壁紙・写真・イラスト・デジタル音楽を販売する、Next.js App RouterベースのデジタルECサイト。',
-  keywords: ['デジタル商品', '壁紙', '写真素材', 'イラスト素材', 'BGM', 'ECサイト'],
-  openGraph: {
-    title: 'Digital Creator Market',
-    description: 'デジタルダウンロード商品を扱うSEO最適化済みECサイト',
-    type: 'website'
-  },
-  alternates: {
-    canonical: '/'
-  }
-};
+export const metadata = buildRootMetadata();
 
 export default async function RootLayout({
   children
@@ -31,6 +14,7 @@ export default async function RootLayout({
   children: React.ReactNode;
 }>) {
   const currentUser = await getCurrentUser();
+  const organizationJsonLd = buildOrganizationJsonLd();
 
   return (
     <html lang="ja">
@@ -38,9 +22,13 @@ export default async function RootLayout({
         <SkipLink />
         <SiteHeader currentUser={currentUser} />
 
-        <main id="main">{children}</main>
+        <div id="main">{children}</div>
 
         <SiteFooter />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationJsonLd) }}
+        />
       </body>
     </html>
   );

--- a/app/og/default/route.tsx
+++ b/app/og/default/route.tsx
@@ -1,0 +1,39 @@
+import { ImageResponse } from 'next/og';
+
+export const runtime = 'edge';
+
+const size = {
+  width: 1200,
+  height: 630
+};
+
+export function GET() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+          padding: '72px',
+          background: 'linear-gradient(135deg, #0f172a 0%, #1d4ed8 100%)',
+          color: '#f8fafc',
+          fontFamily: 'sans-serif'
+        }}
+      >
+        <div style={{ fontSize: 34, color: '#bfdbfe', marginBottom: 24 }}>Digital Creator Market</div>
+        <div style={{ fontSize: 72, fontWeight: 700, lineHeight: 1.1, marginBottom: 24 }}>
+          壁紙・写真・イラスト・デジタル音源を
+          <br />
+          比較して購入できるECサイト
+        </div>
+        <div style={{ fontSize: 30, color: '#dbeafe', lineHeight: 1.4 }}>
+          用途・ライセンス・形式が分かる情報設計で、公開ページを機械可読に整理。
+        </div>
+      </div>
+    ),
+    size
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -110,11 +110,6 @@ export default async function HomePage({ searchParams }: Props) {
     '@context': 'https://schema.org',
     '@graph': [
       {
-        '@type': 'Organization',
-        name: 'Digital Creator Market',
-        url: SITE_ORIGIN
-      },
-      {
         '@type': 'WebSite',
         name: 'Digital Creator Market',
         url: SITE_ORIGIN

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -2,6 +2,13 @@ import type { MetadataRoute } from 'next';
 import { SITE_ORIGIN } from '@/lib/seo/metadata';
 
 const isProduction = process.env.NODE_ENV === 'production';
+const PUBLIC_ALLOW_PATHS = ['/', '/products', '/categories', '/tags', '/faq', '/help', '/legal'];
+const PRIVATE_DISALLOW_PATHS = ['/api/', '/admin/', '/cart/', '/checkout/', '/mypage/', '/search'];
+const FUTURE_CRAWLER_RULES: Array<{
+  userAgent: string | string[];
+  allow?: string | string[];
+  disallow?: string | string[];
+}> = [];
 
 export default function robots(): MetadataRoute.Robots {
   if (!isProduction) {
@@ -14,11 +21,14 @@ export default function robots(): MetadataRoute.Robots {
   }
 
   return {
-    rules: {
-      userAgent: '*',
-      allow: ['/', '/products', '/categories', '/tags', '/help', '/faq', '/contact', '/chat', '/legal'],
-      disallow: ['/api/', '/admin/', '/checkout/', '/cart/', '/mypage/', '/search']
-    },
+    rules: [
+      {
+        userAgent: '*',
+        allow: PUBLIC_ALLOW_PATHS,
+        disallow: PRIVATE_DISALLOW_PATHS
+      },
+      ...FUTURE_CRAWLER_RULES
+    ],
     sitemap: `${SITE_ORIGIN}/sitemap.xml`
   };
 }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,29 +1,31 @@
 import type { MetadataRoute } from 'next';
 import { PRODUCT_CATEGORIES, allTags, products } from '@/data/products';
-import { SITE_ORIGIN } from '@/lib/seo/metadata';
+import { toAbsoluteUrl } from '@/lib/seo/metadata';
 
-function toAbsoluteUrl(path: string) {
-  return new URL(path, SITE_ORIGIN).toString();
-}
+const STATIC_ROUTES: Array<{ path: string; changeFrequency: MetadataRoute.Sitemap[number]['changeFrequency']; priority: number }> = [
+  { path: '/', changeFrequency: 'daily', priority: 1 },
+  { path: '/products', changeFrequency: 'daily', priority: 0.9 },
+  { path: '/categories', changeFrequency: 'weekly', priority: 0.8 },
+  { path: '/tags', changeFrequency: 'weekly', priority: 0.7 },
+  { path: '/faq', changeFrequency: 'weekly', priority: 0.7 },
+  { path: '/help', changeFrequency: 'weekly', priority: 0.7 },
+  { path: '/deals', changeFrequency: 'weekly', priority: 0.6 },
+  { path: '/ranking', changeFrequency: 'weekly', priority: 0.6 },
+  { path: '/legal/tokushoho', changeFrequency: 'yearly', priority: 0.4 },
+  { path: '/legal/terms', changeFrequency: 'yearly', priority: 0.4 },
+  { path: '/legal/privacy', changeFrequency: 'yearly', priority: 0.4 }
+];
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const staticRoutes: MetadataRoute.Sitemap = [
-    { url: toAbsoluteUrl('/'), changeFrequency: 'daily', priority: 1 },
-    { url: toAbsoluteUrl('/products'), changeFrequency: 'daily', priority: 0.9 },
-    { url: toAbsoluteUrl('/categories'), changeFrequency: 'weekly', priority: 0.8 },
-    { url: toAbsoluteUrl('/tags'), changeFrequency: 'weekly', priority: 0.7 },
-    { url: toAbsoluteUrl('/faq'), changeFrequency: 'weekly', priority: 0.6 },
-    { url: toAbsoluteUrl('/help'), changeFrequency: 'weekly', priority: 0.6 },
-    { url: toAbsoluteUrl('/contact'), changeFrequency: 'monthly', priority: 0.5 },
-    { url: toAbsoluteUrl('/chat'), changeFrequency: 'weekly', priority: 0.5 },
-    { url: toAbsoluteUrl('/legal/tokushoho'), changeFrequency: 'yearly', priority: 0.4 },
-    { url: toAbsoluteUrl('/legal/terms'), changeFrequency: 'yearly', priority: 0.4 },
-    { url: toAbsoluteUrl('/legal/privacy'), changeFrequency: 'yearly', priority: 0.4 }
-  ];
+  const staticRoutes: MetadataRoute.Sitemap = STATIC_ROUTES.map((route) => ({
+    url: toAbsoluteUrl(route.path),
+    changeFrequency: route.changeFrequency,
+    priority: route.priority
+  }));
 
   const categoryRoutes: MetadataRoute.Sitemap = PRODUCT_CATEGORIES.map((category) => ({
     url: toAbsoluteUrl(`/categories/${category}`),
-    changeFrequency: 'daily',
+    changeFrequency: 'weekly',
     priority: 0.8
   }));
 
@@ -37,7 +39,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     url: toAbsoluteUrl(`/products/${product.slug}`),
     lastModified: new Date(product.publishedAt),
     changeFrequency: 'weekly',
-    priority: 0.6
+    priority: 0.8
   }));
 
   return [...staticRoutes, ...categoryRoutes, ...tagRoutes, ...productRoutes];

--- a/lib/seo/jsonld.ts
+++ b/lib/seo/jsonld.ts
@@ -1,9 +1,36 @@
 import { getCategoryLabel, type Product } from '@/data/products';
-import { SITE_ORIGIN } from '@/lib/seo/metadata';
-const BRAND_NAME = 'Digital Creator Market';
+import { SITE_NAME, SITE_ORIGIN, toAbsoluteUrl } from '@/lib/seo/metadata';
 
-function toAbsoluteUrl(path: string) {
-  return new URL(path, SITE_ORIGIN).toString();
+const SUPPORT_EMAIL = 'support@example.com';
+
+type FaqItem = {
+  question: string;
+  answer: string;
+};
+
+export function buildOrganizationJsonLd() {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Organization',
+    name: SITE_NAME,
+    url: SITE_ORIGIN,
+    email: SUPPORT_EMAIL
+  };
+}
+
+export function buildFaqJsonLd(items: FaqItem[]) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: items.map((item) => ({
+      '@type': 'Question',
+      name: item.question,
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: item.answer
+      }
+    }))
+  };
 }
 
 export function buildProductJsonLd(product: Product) {
@@ -21,7 +48,7 @@ export function buildProductJsonLd(product: Product) {
     sku: product.sku || product.slug,
     brand: {
       '@type': 'Brand',
-      name: BRAND_NAME
+      name: SITE_NAME
     },
     category: getCategoryLabel(product.category),
     keywords: product.tags.join(', '),

--- a/lib/seo/metadata.ts
+++ b/lib/seo/metadata.ts
@@ -3,7 +3,10 @@ import { getCategoryLabel, type DigitalCategory, type Product } from '@/data/pro
 
 export const SITE_ORIGIN =
   process.env.NEXT_PUBLIC_SITE_ORIGIN?.replace(/\/$/, '') ?? 'http://localhost:3000';
-const SITE_NAME = 'Digital Creator Market';
+export const SITE_NAME = 'Digital Creator Market';
+export const DEFAULT_OG_IMAGE_PATH = '/og/default';
+
+const isProduction = process.env.NODE_ENV === 'production';
 
 type MetadataTemplateInput = {
   title: string;
@@ -12,10 +15,33 @@ type MetadataTemplateInput = {
   openGraphType?: 'website' | 'article';
   imagePaths?: string[];
   robots?: Metadata['robots'];
+  keywords?: string[];
 };
 
-function toAbsoluteUrl(path: string) {
+export function toAbsoluteUrl(path: string) {
   return new URL(path, SITE_ORIGIN).toString();
+}
+
+export function buildIndexableRobots(): Metadata['robots'] {
+  return {
+    index: isProduction,
+    follow: isProduction,
+    googleBot: {
+      index: isProduction,
+      follow: isProduction
+    }
+  };
+}
+
+export function buildNoIndexRobots(follow = true): Metadata['robots'] {
+  return {
+    index: false,
+    follow,
+    googleBot: {
+      index: false,
+      follow
+    }
+  };
 }
 
 function buildMetadataTemplate({
@@ -23,15 +49,17 @@ function buildMetadataTemplate({
   description,
   canonicalPath,
   openGraphType = 'website',
-  imagePaths,
-  robots
+  imagePaths = [DEFAULT_OG_IMAGE_PATH],
+  robots = buildIndexableRobots(),
+  keywords
 }: MetadataTemplateInput): Metadata {
   const canonicalUrl = toAbsoluteUrl(canonicalPath);
-  const imageUrls = imagePaths?.map((path) => toAbsoluteUrl(path));
+  const imageUrls = imagePaths.map((path) => toAbsoluteUrl(path));
 
   return {
     title,
     description,
+    keywords,
     alternates: {
       canonical: canonicalUrl
     },
@@ -39,12 +67,13 @@ function buildMetadataTemplate({
       type: openGraphType,
       url: canonicalUrl,
       siteName: SITE_NAME,
+      locale: 'ja_JP',
       title,
       description,
       images: imageUrls
     },
     twitter: {
-      card: imageUrls?.length ? 'summary_large_image' : 'summary',
+      card: imageUrls.length ? 'summary_large_image' : 'summary',
       title,
       description,
       images: imageUrls
@@ -53,23 +82,68 @@ function buildMetadataTemplate({
   };
 }
 
+export function buildRootMetadata(): Metadata {
+  return {
+    metadataBase: new URL(SITE_ORIGIN),
+    title: {
+      default: SITE_NAME,
+      template: `%s | ${SITE_NAME}`
+    },
+    description:
+      '壁紙・写真・イラスト・デジタル音源を用途・ライセンス・形式から比較し、すぐに購入できるデジタル商品ECサイトです。',
+    keywords: ['デジタル商品', '壁紙', '写真素材', 'イラスト素材', 'BGM', 'ECサイト'],
+    alternates: {
+      canonical: '/'
+    },
+    openGraph: {
+      type: 'website',
+      siteName: SITE_NAME,
+      locale: 'ja_JP',
+      url: SITE_ORIGIN,
+      title: SITE_NAME,
+      description:
+        '壁紙・写真・イラスト・デジタル音源を用途別に比較し、ライセンス条件を確認して購入できるデジタル商品ECサイトです。',
+      images: [toAbsoluteUrl(DEFAULT_OG_IMAGE_PATH)]
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: SITE_NAME,
+      description:
+        '壁紙・写真・イラスト・デジタル音源を用途別に比較し、ライセンス条件を確認して購入できるデジタル商品ECサイトです。',
+      images: [toAbsoluteUrl(DEFAULT_OG_IMAGE_PATH)]
+    },
+    robots: buildIndexableRobots()
+  };
+}
+
 export function buildProductMetadata(product: Product): Metadata {
-  const title = `${product.name} | ${SITE_NAME}`;
-  const description = `${product.description}（カテゴリ: ${getCategoryLabel(product.category)} / 形式: ${product.fileFormat} / ライセンス: ${product.license}）`;
+  const categoryLabel = getCategoryLabel(product.category);
+  const description = `${product.description} 形式: ${product.fileFormat}。ライセンス: ${product.license}。ダウンロード容量: ${product.downloadSizeMB.toLocaleString('ja-JP')}MB。`;
 
   return buildMetadataTemplate({
-    title,
+    title: product.name,
     description,
     canonicalPath: `/products/${product.slug}`,
-    imagePaths: [`/og/product?slug=${encodeURIComponent(product.slug)}`]
+    openGraphType: 'article',
+    imagePaths: [`/og/product?slug=${encodeURIComponent(product.slug)}`],
+    keywords: [categoryLabel, product.fileFormat, product.license, ...product.tags]
   });
 }
 
-export function buildProductListingMetadata(canonicalPath: string): Metadata {
+export function buildProductListingMetadata(input: {
+  canonicalPath: string;
+  isIndexable?: boolean;
+  title?: string;
+  description?: string;
+}): Metadata {
+  const { canonicalPath, isIndexable = canonicalPath === '/products', title, description } = input;
+
   return buildMetadataTemplate({
-    title: '商品一覧',
-    description: '壁紙・イラスト・写真・デジタル音源のダウンロード商品一覧です。',
-    canonicalPath
+    title: title ?? '商品一覧',
+    description:
+      description ?? '壁紙・イラスト・写真・デジタル音源のダウンロード商品を、用途・価格・タグから比較できる一覧ページです。',
+    canonicalPath,
+    robots: isIndexable ? buildIndexableRobots() : buildNoIndexRobots()
   });
 }
 
@@ -77,35 +151,28 @@ export function buildCategoryMetadata(category: DigitalCategory): Metadata {
   const categoryLabel = getCategoryLabel(category);
 
   return buildMetadataTemplate({
-    title: `${categoryLabel}カテゴリ`,
-    description: `${categoryLabel}カテゴリのデジタル商品一覧ページです。`,
-    canonicalPath: `/categories/${category}`
+    title: `${categoryLabel}一覧`,
+    description: `${categoryLabel}カテゴリの商品を用途・形式・ライセンスで比較できる一覧ページです。`,
+    canonicalPath: `/categories/${category}`,
+    keywords: [categoryLabel, 'カテゴリ', 'デジタル商品']
   });
 }
 
 export function buildTagMetadata(tag: string): Metadata {
-  const canonicalPath = `/tags/${encodeURIComponent(tag)}`;
-
   return buildMetadataTemplate({
-    title: `タグ: ${tag}`,
-    description: `${tag}に関連するデジタル商品一覧です。`,
-    canonicalPath,
+    title: `${tag}タグの商品一覧`,
+    description: `${tag}に関連するデジタル商品をまとめて比較できるタグページです。`,
+    canonicalPath: `/tags/${encodeURIComponent(tag)}`,
+    keywords: [tag, 'タグ', 'デジタル商品']
   });
 }
 
-export function buildSearchMetadata(canonicalPath: string): Metadata {
+export function buildSearchMetadata(): Metadata {
   return buildMetadataTemplate({
     title: '検索結果',
     description: 'サイト内検索結果ページです。',
-    canonicalPath,
-  });
-}
-
-export function buildLegalMetadata(): Metadata {
-  return buildMetadataTemplate({
-    title: '特定商取引法に基づく表記',
-    description: 'Digital Creator Market の特定商取引法に基づく表記です。',
-    canonicalPath: '/legal/tokushoho'
+    canonicalPath: '/search',
+    robots: buildNoIndexRobots()
   });
 }
 
@@ -114,22 +181,24 @@ export function buildLegalPageMetadata(input: {
   description: string;
   canonicalPath: string;
 }): Metadata {
-  return buildMetadataTemplate(input);
+  return buildMetadataTemplate({
+    ...input,
+    keywords: ['法律', '規約', 'サポート']
+  });
 }
 
 export function buildCategoryHubMetadata(): Metadata {
   return buildMetadataTemplate({
     title: 'カテゴリ一覧',
-    description: '壁紙・写真・イラスト・音源など用途別カテゴリから商品を探せる一覧ページです。',
+    description: '壁紙・写真・イラスト・デジタル音源のカテゴリ別に商品を探せる一覧ページです。',
     canonicalPath: '/categories'
   });
 }
 
-
 export function buildDealsMetadata(): Metadata {
   return buildMetadataTemplate({
     title: 'セール・クーポン特集',
-    description: '期間限定セールやクーポン配布情報をまとめた特集ページです。',
+    description: '価格訴求の高い商品やクーポン関連導線をまとめた特集ページです。',
     canonicalPath: '/deals'
   });
 }
@@ -137,22 +206,23 @@ export function buildDealsMetadata(): Metadata {
 export function buildRankingMetadata(): Metadata {
   return buildMetadataTemplate({
     title: '人気ランキング',
-    description: '売れ筋・お気に入り登録数の高いデジタル商品のランキングです。',
+    description: '売れ筋や注目度の高いデジタル商品のランキングページです。',
     canonicalPath: '/ranking'
   });
 }
+
 export function buildTagHubMetadata(): Metadata {
   return buildMetadataTemplate({
     title: 'タグ一覧',
-    description: '人気タグからデジタル商品を横断的に探せるハブページです。',
+    description: '利用シーンやテイスト別のタグから関連商品を探せる一覧ページです。',
     canonicalPath: '/tags'
   });
 }
 
 export function buildFaqMetadata(): Metadata {
   return buildMetadataTemplate({
-    title: 'よくある質問（FAQ）',
-    description: '購入前後のよくある質問と回答をまとめたサポートページです。',
+    title: 'よくある質問',
+    description: '購入前後によくある質問を、支払い・ライセンス・ダウンロード単位で整理したFAQページです。',
     canonicalPath: '/faq'
   });
 }
@@ -160,7 +230,7 @@ export function buildFaqMetadata(): Metadata {
 export function buildHelpMetadata(): Metadata {
   return buildMetadataTemplate({
     title: 'ヘルプセンター',
-    description: '注文・配送・支払い・返品・アカウントに関するサポート導線を集約しています。',
+    description: '購入方法、ライセンス、ダウンロード、問い合わせ導線を短く整理したヘルプページです。',
     canonicalPath: '/help'
   });
 }
@@ -168,15 +238,17 @@ export function buildHelpMetadata(): Metadata {
 export function buildContactMetadata(): Metadata {
   return buildMetadataTemplate({
     title: 'お問い合わせ',
-    description: '注文・商品・アカウントに関するお問い合わせを受け付けています。',
-    canonicalPath: '/contact'
+    description: '注文、商品仕様、ライセンス、アカウントに関する問い合わせ窓口ページです。',
+    canonicalPath: '/contact',
+    robots: buildNoIndexRobots()
   });
 }
 
 export function buildMissingProductMetadata(): Metadata {
   return buildMetadataTemplate({
     title: '商品が見つかりません',
-    description: '指定されたデジタル商品は存在しません。',
-    canonicalPath: '/products'
+    description: '指定されたデジタル商品は見つかりませんでした。商品一覧から再度お探しください。',
+    canonicalPath: '/products',
+    robots: buildNoIndexRobots()
   });
 }


### PR DESCRIPTION
### Motivation
- 生成AI／LLM や検索エンジンが理解しやすい情報設計（AEO）を最小差分で導入し、公開ページの crawl/index 制御・metadata・JSON-LD を一貫化するため。 
- Next.js の既存設計（App Router / Metadata API / Route Handlers）を尊重しつつ、チャット導線と AWS コストに影響を与えない実装にするため。

### Description
- `lib/seo/metadata.ts` を再設計してルート共通 metadata（title/description/canonical/OG/Twitter/robots/keywords）を集約し、`buildRootMetadata()` 等で統一出力するようにしました。 
- 構造化データを強化するため `lib/seo/jsonld.ts` を拡張し、`Organization` / `FAQPage` / `Product` の生成関数を追加・整理し、ルートで `Organization` JSON-LD を出力するように `app/layout.tsx` を更新しました。 
- クロール方針を整理するため `app/robots.ts` を本番限定の大枠ルールに変更し、将来の user-agent 個別制御用フック（`FUTURE_CRAWLER_RULES`）を追加しました。内部検索や個人領域は非公開扱いにしています。 
- サイトマップを `app/sitemap.ts` で公開価値の高い静的ページ／カテゴリ／タグ／商品に限定し、`/contact` や `/chat` 等の index 優先度が低いページは除外しました。 
- 商品詳細ページに「この商品は何か / 誰向けか / 利用シーン / 形式 / ライセンス / 入手方法 / 注意事項」の短い要点要約セクションを追加して、AI 検索／要約で抜き出しやすい本文構造に改善しました（購入・チャット導線は維持）。 
- FAQ / Help / Contact / Legal ページの見出し階層と本文構造を整理し、FAQ は共通 `FAQPage` JSON-LD を利用するように統一しました。 
- 共通 OG が未整備だったため `app/og/default/route.tsx` を追加し、OG 画像の一貫化を図りました。 
- 変更ファイル（主なもの）: `lib/seo/metadata.ts`, `lib/seo/jsonld.ts`, `app/robots.ts`, `app/sitemap.ts`, `app/layout.tsx`, `app/og/default/route.tsx`, `app/(store)/products/[slug]/page.tsx`, `app/(store)/products/page.tsx`, `app/(store)/search/page.tsx`, `app/(store)/faq/page.tsx`, `app/(store)/help/page.tsx`, `app/(store)/contact/page.tsx`, `app/(store)/categories/[category]/page.tsx`, `app/(store)/tags/[tag]/page.tsx`, `app/(store)/legal/LegalPageTemplate.tsx`。

### Testing
- 実行した自動テスト（CI 相当のローカル検証）: 
  - `npm run lint` — PASS
  - `npm run build` — PASS（ビルド成功、静的ページ生成・edge routes の生成を確認）
  - `git diff --check` — PASS
- ビルドログでページ生成と prerender が正常に完了していること、edge runtime を使う OG ルートや既存の SSE / チャット API に影響がないことを確認しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69badfd8ef70832899bb1df66b26a004)