### PR TITLE
ECS: NEXT_PUBLIC_SITE_ORIGIN 注入とデプロイを immutable SHA タグ化

### DIFF
--- a/.github/workflows/deploy-ecs-ec2.yml
+++ b/.github/workflows/deploy-ecs-ec2.yml
@@ -48,8 +48,9 @@ jobs:
           REGISTRY: ${{ steps.ecr.outputs.registry }}
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          docker build -t "$REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" .
+          docker build -t "$REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" -t "$REGISTRY/$ECR_REPOSITORY:latest" .
           docker push "$REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+          docker push "$REGISTRY/$ECR_REPOSITORY:latest"
 
       - name: Register ECS task definition revision with immutable image tag
         env:

--- a/.github/workflows/deploy-ecs-ec2.yml
+++ b/.github/workflows/deploy-ecs-ec2.yml
@@ -48,15 +48,51 @@ jobs:
           REGISTRY: ${{ steps.ecr.outputs.registry }}
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          docker build -t "$REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" -t "$REGISTRY/$ECR_REPOSITORY:latest" .
+          docker build -t "$REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" .
           docker push "$REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
-          docker push "$REGISTRY/$ECR_REPOSITORY:latest"
 
-      - name: Force new ECS deployment
+      - name: Register ECS task definition revision with immutable image tag
+        env:
+          REGISTRY: ${{ steps.ecr.outputs.registry }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          IMAGE_URI="$REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+
+          TASK_DEF_ARN="$(aws ecs describe-services \
+            --cluster "$ECS_CLUSTER" \
+            --services "$ECS_SERVICE" \
+            --query 'services[0].taskDefinition' \
+            --output text)"
+
+          aws ecs describe-task-definition \
+            --task-definition "$TASK_DEF_ARN" \
+            --query 'taskDefinition' \
+            --output json > task-definition.json
+
+          jq --arg IMAGE_URI "$IMAGE_URI" '
+            del(.taskDefinitionArn, .revision, .status, .requiresAttributes, .compatibilities, .registeredAt, .registeredBy)
+            | .containerDefinitions |= map(
+              if .name == "app" then
+                .image = $IMAGE_URI
+              else
+                .
+              end
+            )
+          ' task-definition.json > task-definition-rendered.json
+
+          NEW_TASK_DEF_ARN="$(aws ecs register-task-definition \
+            --cli-input-json file://task-definition-rendered.json \
+            --query 'taskDefinition.taskDefinitionArn' \
+            --output text)"
+
+          echo "NEW_TASK_DEF_ARN=$NEW_TASK_DEF_ARN" >> "$GITHUB_ENV"
+
+      - name: Deploy ECS service with new task definition
         run: |
           aws ecs update-service \
             --cluster "$ECS_CLUSTER" \
             --service "$ECS_SERVICE" \
+            --task-definition "$NEW_TASK_DEF_ARN" \
             --force-new-deployment
           aws ecs wait services-stable \
             --cluster "$ECS_CLUSTER" \

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -267,6 +267,10 @@ resource "aws_ecs_task_definition" "app" {
           value = aws_ssm_parameter.app["SITE_URL"].value
         },
         {
+          name  = "NEXT_PUBLIC_SITE_ORIGIN"
+          value = aws_ssm_parameter.app["SITE_URL"].value
+        },
+        {
           name  = "CHAT_STORAGE_MODE"
           value = aws_ssm_parameter.app["CHAT_STORAGE_MODE"].value
         },


### PR DESCRIPTION
### Motivation
- 本番で生成される canonical / OG URL が `NEXT_PUBLIC_SITE_ORIGIN` に依存しているがタスク定義に注入されておらず `http://localhost:3000` にフォールバックしていたため、SEO/AEO の劣化を防ぐ必要がありました。
- 既存ワークフローが `:latest` を使っているためデプロイやロールバックが非決定的となり、本番の再現性と安全性を担保するためイメージ参照を不変の `github.sha` に変更する必要がありました。

### Description
- `infra/terraform/main.tf` の ECS タスク定義環境変数に `NEXT_PUBLIC_SITE_ORIGIN` を追加し、既存の `SITE_URL`（SSM パラメータ）と同じ値を注入するようにしました。 (`infra/terraform/main.tf`)
- デプロイワークフローの Docker push を `:latest` を使わないようにして `github.sha` のみを push するよう変更しました。 (`.github/workflows/deploy-ecs-ec2.yml`)
- デプロイ時に現在のサービスの Task Definition を取得して `app` コンテナの `image` を `sha` に差し替えた新しいタスク定義リビジョンを `register-task-definition` で登録し、その新規 ARN を使ってサービスを更新するフローに変更しました。 (`.github/workflows/deploy-ecs-ec2.yml`)

### Testing
- `npm run lint` を実行し `PASS`（ESLint 問題なし）。
- `npm run build` を実行し `PASS`（Next.js ビルド成功、静的ページ生成完了）。
- `terraform -chdir=infra/terraform fmt -check` は実行環境に `terraform` が未インストールのため `FAIL`。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca2f84f1d08328a843d21142db9528)