### PR TITLE
Add AWS architecture docs: current Terraform diagram and future Fargate proposal

### DIFF
--- a/docs/aws/future-architecture-proposal.md
+++ b/docs/aws/future-architecture-proposal.md
@@ -1,0 +1,43 @@
+# AWS 将来構成案アーキテクチャ図（提案）
+
+将来スケールを見据えた構成案です。現行 Terraform 実装とは別に、段階的移行を想定した図として記載します。
+
+```mermaid
+flowchart TB
+  User["User Browser"] --> R53["Route 53"]
+  R53 --> WAF["AWS WAF"]
+  WAF --> CF["CloudFront"]
+
+  CF --> S3["S3\n(静的アセット)"]
+  CF --> ALB["Application Load Balancer"]
+
+  subgraph PrivateSubnets["Private Subnets"]
+    ECS["ECS Fargate Service\n(Next.js)"]
+    Worker["ECS Fargate Worker\n(Chat非同期処理)"]
+    Redis["ElastiCache Redis\n(セッション/キャッシュ)"]
+    RDS["Aurora PostgreSQL"]
+  end
+
+  ALB --> ECS
+  ECS --> Redis
+  ECS --> RDS
+  ECS --> SQS["SQS\n(Chat Queue)"]
+  Worker --> SQS
+  Worker --> RDS
+
+  ECS --> CW["CloudWatch Logs / Metrics"]
+  Worker --> CW
+
+  ECS --> SM["Secrets Manager"]
+  ECS --> SSM["SSM Parameter Store"]
+  Worker --> SM
+  Worker --> SSM
+
+  GH["GitHub Actions\nOIDC"] --> IAM["IAM OIDC Role"]
+  IAM --> ECR["ECR"]
+  IAM --> ECS
+```
+
+## 補足
+- 本図は「将来構成案」であり、現行の `infra/terraform/main.tf` にそのまま一致するものではありません。
+- 目的は、配信最適化（CloudFront）、可用性向上（Fargate + ALB）、データ永続化（Aurora）、チャット負荷分離（SQS + Worker）の方向性を可視化することです。

--- a/docs/aws/terraform-current-architecture.md
+++ b/docs/aws/terraform-current-architecture.md
@@ -1,0 +1,55 @@
+# Terraform 実装ベース AWS アーキテクチャ図（現行）
+
+この図は `infra/terraform/*.tf` から読み取れる **実装済み構成のみ** を反映しています。
+
+```mermaid
+flowchart TB
+  subgraph Internet
+    User["User Browser"]
+    GH["GitHub Actions\nOIDC"]
+  end
+
+  subgraph AWS["AWS Account"]
+    OIDC["IAM OIDC Provider\n(token.actions.githubusercontent.com)"]
+    CIRole["IAM Role\nGitHub Actions CI"]
+
+    subgraph DefaultVPC["Default VPC"]
+      EC2SG["Security Group\nIngress: container_port"]
+      EC2["EC2 (ECS Optimized AMI)\nECS Container Instance"]
+    end
+
+    ECSCluster["ECS Cluster"]
+    ECSService["ECS Service (EC2 launch)\ndesired=1"]
+    TaskDef["ECS Task Definition\nbridge mode"]
+    App["Next.js App Container"]
+
+    ECR["ECR Repository\n:latest image"]
+    CWL["CloudWatch Logs\n/ecs/{project-env}"]
+
+    SSMParam["SSM Parameter Store\n(APP_ENV, SITE_URL, etc.)"]
+    Secrets["Secrets Manager\n(DATABASE_URL, JWT_SECRET, SESSION_SECRET)"]
+
+    TaskExecRole["IAM Role\nECS Task Execution"]
+    TaskRole["IAM Role\nECS Task"]
+    EC2Role["IAM Role\nECS Instance + SSM Managed"]
+  end
+
+  User -->|HTTP :3000| EC2SG --> EC2
+
+  EC2 --> ECSCluster --> ECSService --> TaskDef --> App
+
+  App --> CWL
+  App -->|pull image| ECR
+  App -->|env| SSMParam
+  App -->|secrets| Secrets
+
+  TaskDef --> TaskExecRole
+  TaskDef --> TaskRole
+  EC2 --> EC2Role
+
+  GH -->|AssumeRoleWithWebIdentity| OIDC
+  OIDC --> CIRole
+  CIRole -->|ECR push / ECS update| ECR
+  CIRole -->|register task def / update service| ECSService
+
+```


### PR DESCRIPTION
### Motivation
- Provide a clear, visual reference of the current AWS setup as implemented by `infra/terraform/*.tf` to help onboarding and maintenance.  
- Propose a scalable target architecture (CloudFront, ALB, Fargate, Aurora, ElastiCache, SQS + Workers, IAM OIDC) to guide a phased migration from the current EC2/ECS setup.

### Description
- Add `docs/aws/terraform-current-architecture.md` containing a Mermaid diagram that reflects the implemented Terraform-based architecture and the exact resources and IAM roles used today.  
- Add `docs/aws/future-architecture-proposal.md` containing a Mermaid diagram that outlines a proposed future architecture using CloudFront, S3, ALB, ECS Fargate, Aurora PostgreSQL, ElastiCache Redis, SQS and worker services, and GitHub Actions OIDC for deployments.  
- Include explanatory notes in the future proposal clarifying that it is a target/transition design and does not directly match `infra/terraform/main.tf` line-for-line.

### Testing
- No automated tests were run for these documentation changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0ad7104708328bf6ec343a5950298)