### PR TITLE
[codex] develop 前提の CI/CD 運用を整理

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,10 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, develop]
     types: [opened, synchronize, reopened, ready_for_review]
   push:
-    branches: [main]
+    branches: [main, develop]
 
 jobs:
   verify:

--- a/.github/workflows/infra-terraform.yml
+++ b/.github/workflows/infra-terraform.yml
@@ -7,7 +7,7 @@ on:
       - "infra/terraform/**"
       - ".github/workflows/infra-terraform.yml"
   pull_request:
-    branches: [main]
+    branches: [main, develop]
     paths:
       - "infra/terraform/**"
       - ".github/workflows/infra-terraform.yml"
@@ -23,7 +23,7 @@ env:
   TF_STATE_KEY: ${{ vars.TF_STATE_KEY != '' && vars.TF_STATE_KEY || 'infra/terraform/prod.tfstate' }}
 
 jobs:
-  terraform:
+  plan:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -73,9 +73,59 @@ jobs:
         run: terraform validate
 
       - name: Terraform plan
-        if: github.event_name == 'pull_request'
         run: terraform plan
 
+  apply:
+    if: github.event_name == 'workflow_dispatch'
+    needs: plan
+    runs-on: ubuntu-latest
+    environment: production
+    defaults:
+      run:
+        working-directory: infra/terraform
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.11.4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Render Terraform variables
+        run: |
+          cat > terraform.auto.tfvars.json <<EOF
+          {
+            "aws_region": "${{ vars.AWS_REGION }}",
+            "project_name": "${{ vars.TF_PROJECT_NAME }}",
+            "env": "${{ vars.TF_ENV }}",
+            "instance_type": "${{ vars.TF_INSTANCE_TYPE }}",
+            "container_port": ${{ vars.TF_CONTAINER_PORT }},
+            "public_ingress_cidrs": ${{ vars.TF_PUBLIC_INGRESS_CIDRS }},
+            "ssm_parameters": ${{ vars.TF_SSM_PARAMETERS_JSON }},
+            "secrets_manager_values": ${{ secrets.TF_SECRETS_MANAGER_VALUES_JSON }}
+          }
+          EOF
+
+      - name: Terraform init
+        run: |
+          terraform init \
+            -backend-config="bucket=${{ vars.TF_STATE_BUCKET }}" \
+            -backend-config="key=${{ env.TF_STATE_KEY }}" \
+            -backend-config="region=${{ vars.AWS_REGION }}" \
+            -backend-config="dynamodb_table=${{ vars.TF_LOCK_TABLE }}" \
+            -backend-config="encrypt=true"
+
+      - name: Terraform fmt
+        run: terraform fmt -check -recursive
+
+      - name: Terraform validate
+        run: terraform validate
+
       - name: Terraform apply
-        if: github.event_name != 'pull_request'
         run: terraform apply -auto-approve

--- a/README.md
+++ b/README.md
@@ -108,8 +108,9 @@ Terraform 出力で以下を取得します。
 
 ## GitHub Actions デプロイ
 
-`.github/workflows/infra-terraform.yml` は Terraform の `plan/apply` を実行します。  
-`.github/workflows/deploy-ecs-ec2.yml` はアプリの build / image push / ECS 反映を実行します。
+`.github/workflows/ci.yml` は `develop` / `main` の PR と push で lint / typecheck / build を実行します。
+`.github/workflows/deploy-ecs-ec2.yml` は `main` push または手動実行でアプリの build / image push / ECS 反映を実行します。
+`.github/workflows/infra-terraform.yml` は PR / `main` push では Terraform の `plan` まで実行し、`apply` は手動実行 + `production` Environment 承認後のみ実行します。
 
 ### GitHub Variables
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,3 +4,4 @@
 - porposals.md : 開発中の提案・問題を管理
 - wiki/ : 開発中のknowledgeを蓄積(なるべく不変なもの)
 - local/ : ローカルでプロジェクトを動かすときの手順書
+- git/ : Git flow / CI/CD 運用方針

--- a/docs/git/development-flow.md
+++ b/docs/git/development-flow.md
@@ -1,0 +1,53 @@
+# Git flow / CI/CD 運用
+
+このドキュメントは、開発ブランチ、CI、アプリデプロイ、Terraform によるインフラ変更の運用方針を整理する。
+
+## ブランチ方針
+
+```text
+feature/* -> develop -> main
+```
+
+- 通常開発は `feature/*` から `develop` へ PR を作成する
+- `develop` はメイン開発ブランチとして CI / ローカル動作確認の基準にする
+- 本番反映は `develop` から `main` へ PR を作成する
+- `main` は本番反映対象ブランチとして扱う
+
+## CI
+
+- CI は `develop` / `main` への PR と push で実行する
+- CI では lint / typecheck / build を確認する
+- SEO / AEO に影響する変更では metadata、JSON-LD、heading、内部リンクの劣化がないことをセルフレビューする
+
+対象 workflow:
+
+- `.github/workflows/ci.yml`
+
+## アプリデプロイ
+
+- アプリは `main` push をトリガーに ECS on EC2 へ自動デプロイする
+- アプリデプロイは GitHub Actions の `workflow_dispatch` でも手動実行できる
+- デプロイ対象は ECS on EC2 の single-instance / single-task 構成とする
+- 手動デプロイは緊急時の再実行や、本番反映の明示実行が必要な場合に使う
+
+対象 workflow:
+
+- `.github/workflows/deploy-ecs-ec2.yml`
+
+## Terraform / インフラ変更
+
+- Terraform は PR / `main` push では `plan` まで自動実行する
+- Terraform の `apply` は GitHub Actions の手動実行 + `production` Environment 承認後のみ実行する
+- アプリデプロイとインフラ変更は分離して扱う
+- インフラ変更はアプリデプロイより影響範囲が大きいため、自動 apply は行わない
+
+対象 workflow:
+
+- `.github/workflows/infra-terraform.yml`
+
+## 運用上の注意
+
+- `production` Environment には承認者を設定する
+- Terraform plan の結果を確認してから apply を承認する
+- ECS on EC2 の現行構成では ALB なし、EC2 直接公開、desired count 1 を前提にする
+- chat は single-instance 前提のため、水平分散や Blue/Green 化は別途設計する


### PR DESCRIPTION
### 1) 実装・修正内容
- CI workflow の対象ブランチに `develop` を追加しました。
- Terraform workflow を `plan` job と `apply` job に分離しました。
- Terraform の `apply` を `workflow_dispatch` かつ `production` Environment 承認後のみ実行する構成に変更しました。
- Git flow / CI/CD 運用方針を `docs/git/development-flow.md` に追加しました。
- `docs/README.md` に `git/` ディレクトリの説明を追加しました。
- README の GitHub Actions デプロイ説明を現行 workflow に合わせて更新しました。

### 2) 実装理由
- `develop` をメイン開発ブランチとして扱う方針に合わせ、PR / push 時の CI 対象に追加するためです。
- アプリデプロイと Terraform によるインフラ変更は影響範囲が異なるため、責務を分離しました。
- Terraform の `apply` は ECS / EC2 / IAM / Secrets など本番インフラへ直接影響するため、自動実行ではなく手動実行と `production` Environment 承認を必須にしました。
- 方針 1「Next.js の最新設計」については、Next.js App Router / standalone 構成を壊さず CI で build を継続確認する運用にしています。
- 方針 2「SEO / AEO」については、CI 対象拡張により本番反映前の build 検証を維持し、docs 側に SEO / AEO 変更時のセルフレビュー観点を明記しました。
- 方針 3「リアルタイムチャット機能」については、ECS on EC2 の single-instance 前提を docs に明記し、水平分散は別設計としました。
- 方針 4「AWS 最小コスト」については、ECS on EC2 の現行 single-instance / single-task 構成を維持し、追加リソースを作らない変更にしています。
- 比較案として Terraform `main` push 自動 apply もありましたが、本番インフラ変更のリスクが高いため採用しませんでした。

### 3) 変更ファイル
- `.github/workflows/ci.yml`: `develop` / `main` の PR と push で CI を実行するよう変更。
- `.github/workflows/infra-terraform.yml`: Terraform plan と apply を分離し、apply を手動承認付きに変更。
- `README.md`: GitHub Actions デプロイ説明を現行運用に合わせて更新。
- `docs/README.md`: `git/` ディレクトリの説明を追加。
- `docs/git/development-flow.md`: Git flow / CI/CD / Terraform apply 運用方針を追加。

### 4) 動作確認
```bash
# PASS
terraform fmt -check -recursive

# PASS
python3 -c "import yaml, sys; [yaml.safe_load(open(f)) for f in sys.argv[1:]]; print('workflow yaml ok')" .github/workflows/ci.yml .github/workflows/infra-terraform.yml .github/workflows/deploy-ecs-ec2.yml

# PASS
git diff --check

# FAIL
terraform validate
# ローカルの AWS provider plugin schema 読み込みで失敗しました。

# FAIL
npm run lint / npx tsc --noEmit / npm run build
# ローカル環境に node / npm が無いため未実行です。
```

### 5) 影響範囲
- Next.js 最新設計への整合性: アプリコード変更なし。CI 対象拡張により build 検証範囲を維持します。
- SEO 影響: UI / metadata / JSON-LD 変更なし。直接影響はありません。
- リアルタイムチャット機能への影響: アプリコード変更なし。docs で single-instance 前提を明記しています。
- AWS コスト影響（増減見込み）: 追加 AWS リソースなし。コスト増減はありません。

### 6) 提案・懸念点
- GitHub の `production` Environment に承認者を設定しないと、workflow 上の承認ゲートとして機能しません。
- ローカル環境に node / npm が無いため、Next.js の lint / typecheck / build は GitHub Actions 側で確認が必要です。
- `terraform validate` はローカル provider plugin の schema 読み込みで失敗したため、GitHub Actions 上の Terraform plan 結果確認が必要です。
- Terraform backend の `dynamodb_table` は Terraform 1.14 で deprecated warning が出ているため、別途対応候補です。

### 7) リスクとロールバック
- 想定リスク: `develop` を未作成または保護設定未整備のまま運用すると、PR / CI フローが期待どおりに機能しない可能性があります。
- 想定リスク: `production` Environment の承認設定がない場合、Terraform apply の承認運用が不十分になります。
- ロールバック方法: 本 PR を revert することで、CI 対象ブランチと Terraform workflow を変更前に戻せます。