### PR TITLE
GitHub Actions の AWS 設定検証を追加

### DIFF
--- a/.github/workflows/deploy-ecs-ec2.yml
+++ b/.github/workflows/deploy-ecs-ec2.yml
@@ -9,16 +9,15 @@ permissions:
   id-token: write
   contents: read
 
-env:
-  AWS_REGION: ${{ vars.AWS_REGION }}
-  ECS_CLUSTER: ${{ vars.ECS_CLUSTER_NAME }}
-  ECS_SERVICE: ${{ vars.ECS_SERVICE_NAME }}
-  ECR_REPOSITORY: ${{ vars.ECR_REPOSITORY_NAME }}
-
 jobs:
   deploy:
     runs-on: ubuntu-latest
     environment: production
+    env:
+      AWS_REGION: ${{ vars.AWS_REGION || 'ap-northeast-1' }}
+      ECS_CLUSTER: ${{ vars.ECS_CLUSTER_NAME }}
+      ECS_SERVICE: ${{ vars.ECS_SERVICE_NAME }}
+      ECR_REPOSITORY: ${{ vars.ECR_REPOSITORY_NAME }}
     concurrency:
       group: deploy-production
       cancel-in-progress: false
@@ -36,6 +35,23 @@ jobs:
 
       - name: Build app
         run: npm run build
+
+      - name: Validate deployment configuration
+        env:
+          AWS_CI_ROLE_ARN: ${{ secrets.AWS_CI_ROLE_ARN }}
+        run: |
+          missing=0
+
+          for name in AWS_CI_ROLE_ARN AWS_REGION ECS_CLUSTER ECS_SERVICE ECR_REPOSITORY; do
+            if [ -z "${!name}" ]; then
+              echo "::error title=Missing GitHub configuration::$name is required for ECS deployment."
+              missing=1
+            fi
+          done
+
+          if [ "$missing" -ne 0 ]; then
+            exit 1
+          fi
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6

--- a/.github/workflows/infra-terraform.yml
+++ b/.github/workflows/infra-terraform.yml
@@ -19,7 +19,7 @@ permissions:
   pull-requests: write
 
 env:
-  AWS_REGION: ${{ vars.AWS_REGION }}
+  AWS_REGION: ${{ vars.AWS_REGION || 'ap-northeast-1' }}
   TF_IN_AUTOMATION: true
   TF_STATE_KEY: ${{ vars.TF_STATE_KEY != '' && vars.TF_STATE_KEY || 'infra/terraform/prod.tfstate' }}
 
@@ -39,6 +39,32 @@ jobs:
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: 1.11.4
+
+      - name: Validate Terraform configuration
+        env:
+          AWS_CI_ROLE_ARN: ${{ secrets.AWS_CI_ROLE_ARN }}
+          TF_STATE_BUCKET: ${{ vars.TF_STATE_BUCKET }}
+          TF_LOCK_TABLE: ${{ vars.TF_LOCK_TABLE }}
+          TF_PROJECT_NAME: ${{ vars.TF_PROJECT_NAME }}
+          TF_ENV: ${{ vars.TF_ENV }}
+          TF_INSTANCE_TYPE: ${{ vars.TF_INSTANCE_TYPE }}
+          TF_CONTAINER_PORT: ${{ vars.TF_CONTAINER_PORT }}
+          TF_PUBLIC_INGRESS_CIDRS: ${{ vars.TF_PUBLIC_INGRESS_CIDRS }}
+          TF_SSM_PARAMETERS_JSON: ${{ vars.TF_SSM_PARAMETERS_JSON }}
+          TF_SECRETS_MANAGER_VALUES_JSON: ${{ secrets.TF_SECRETS_MANAGER_VALUES_JSON }}
+        run: |
+          missing=0
+
+          for name in AWS_CI_ROLE_ARN AWS_REGION TF_STATE_BUCKET TF_LOCK_TABLE TF_PROJECT_NAME TF_ENV TF_INSTANCE_TYPE TF_CONTAINER_PORT TF_PUBLIC_INGRESS_CIDRS TF_SSM_PARAMETERS_JSON TF_SECRETS_MANAGER_VALUES_JSON; do
+            if [ -z "${!name}" ]; then
+              echo "::error title=Missing GitHub configuration::$name is required for Terraform plan."
+              missing=1
+            fi
+          done
+
+          if [ "$missing" -ne 0 ]; then
+            exit 1
+          fi
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
@@ -166,6 +192,32 @@ jobs:
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: 1.11.4
+
+      - name: Validate Terraform configuration
+        env:
+          AWS_CI_ROLE_ARN: ${{ secrets.AWS_CI_ROLE_ARN }}
+          TF_STATE_BUCKET: ${{ vars.TF_STATE_BUCKET }}
+          TF_LOCK_TABLE: ${{ vars.TF_LOCK_TABLE }}
+          TF_PROJECT_NAME: ${{ vars.TF_PROJECT_NAME }}
+          TF_ENV: ${{ vars.TF_ENV }}
+          TF_INSTANCE_TYPE: ${{ vars.TF_INSTANCE_TYPE }}
+          TF_CONTAINER_PORT: ${{ vars.TF_CONTAINER_PORT }}
+          TF_PUBLIC_INGRESS_CIDRS: ${{ vars.TF_PUBLIC_INGRESS_CIDRS }}
+          TF_SSM_PARAMETERS_JSON: ${{ vars.TF_SSM_PARAMETERS_JSON }}
+          TF_SECRETS_MANAGER_VALUES_JSON: ${{ secrets.TF_SECRETS_MANAGER_VALUES_JSON }}
+        run: |
+          missing=0
+
+          for name in AWS_CI_ROLE_ARN AWS_REGION TF_STATE_BUCKET TF_LOCK_TABLE TF_PROJECT_NAME TF_ENV TF_INSTANCE_TYPE TF_CONTAINER_PORT TF_PUBLIC_INGRESS_CIDRS TF_SSM_PARAMETERS_JSON TF_SECRETS_MANAGER_VALUES_JSON; do
+            if [ -z "${!name}" ]; then
+              echo "::error title=Missing GitHub configuration::$name is required for Terraform apply."
+              missing=1
+            fi
+          done
+
+          if [ "$missing" -ne 0 ]; then
+            exit 1
+          fi
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6


### PR DESCRIPTION
### 1) 実装・修正内容
- `.github/workflows/deploy-ecs-ec2.yml` で `AWS_REGION` の fallback と deploy 前の必須設定チェックを追加しました。
- `.github/workflows/infra-terraform.yml` で `AWS_REGION` の fallback と Terraform plan/apply 前の必須設定チェックを追加しました。
- `configure-aws-credentials` 実行前に GitHub Variables / Secrets の不足を明示的な `::error` として出すようにしました。

### 2) 実装理由
- 直接原因は `aws-actions/configure-aws-credentials@v6` に必須入力 `aws-region` が空で渡っていたことです。AWS 公式 action の README では `aws-region` は必須入力と明記されています。
- GitHub 公式 docs では、未設定の `vars` context は空文字として評価されるため、`vars.AWS_REGION` が未設定の場合に今回のエラーが再現します。
- GitHub 公式 docs では expressions の `||` 演算子と falsy 値としての空文字が定義されているため、既存 repo の標準値である `ap-northeast-1` を fallback として採用しました。
- `AWS_REGION` だけを補うと、次に `ECS_CLUSTER_NAME` / `ECS_SERVICE_NAME` / `ECR_REPOSITORY_NAME` などの未設定で後続 AWS CLI が失敗します。そのため AWS API 実行前に必須設定をまとめて検証する実装にしました。
- 考慮した方針: 4. AWS に最小コストでデプロイする。CI/CD 設定不備を早期に検出し、不要な AWS API 実行や途中失敗を避けるためです。
- 比較案: GitHub Variables の設定手順のみで対応する案もありますが、設定漏れが再発した場合に同じ不明瞭な失敗になります。workflow 側で検証する方が保守性が高いため却下しました。

公式参照:
- https://github.com/aws-actions/configure-aws-credentials
- https://docs.github.com/en/actions/reference/workflows-and-actions/contexts
- https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions
- https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions

### 3) 変更ファイル
- `.github/workflows/deploy-ecs-ec2.yml`: ECS deploy workflow の AWS region fallback と必須設定検証を追加。
- `.github/workflows/infra-terraform.yml`: Terraform plan/apply workflow の AWS region fallback と必須設定検証を追加。

### 4) 動作確認
```bash
npm run lint
# PASS

npm run build
# PASS

node -e "const fs=require('fs'); const yaml=require('js-yaml'); for (const f of ['.github/workflows/deploy-ecs-ec2.yml','.github/workflows/infra-terraform.yml']) { yaml.load(fs.readFileSync(f,'utf8')); console.log('OK '+f); }"
# PASS

git diff --check
# PASS
```

手動確認:
- 公式情報を参照し、`aws-region` 必須、未設定 `vars` の空文字評価、`||` fallback、workflow command の `::error` 利用が妥当であることを確認しました。

### 5) 影響範囲
- Next.js 最新設計への整合性: なし。アプリケーションコード、App Router、metadata、runtime 実装には変更なし。
- SEO 影響: なし。ページ、metadata、JSON-LD、sitemap、robots には変更なし。
- リアルタイムチャット機能への影響: なし。チャット関連 API / component / storage には変更なし。
- AWS コスト影響（増減見込み）: なし。リソース定義は変更せず、GitHub Actions の設定検証のみ追加。

### 6) 提案・懸念点
- `ECS_CLUSTER_NAME` / `ECS_SERVICE_NAME` / `ECR_REPOSITORY_NAME` は Terraform outputs から取得して GitHub Variables に設定する運用が必要です。
- Terraform plan job は `production` Environment を宣言していないため、Terraform 用 Variables は repository-level Variables として置く運用が安全です。
- `AWS_REGION` は fallback で `ap-northeast-1` になりますが、別リージョン運用にする場合は GitHub Variables の `AWS_REGION` を明示設定してください。

### 7) リスクとロールバック
- リスク: 必須設定が不足している場合、従来より早い段階で workflow が失敗します。ただし失敗理由は明確になります。
- リスク: `AWS_REGION` を意図的に別リージョンへ設定していない場合、fallback により `ap-northeast-1` が使われます。
- ロールバック方法: この PR の workflow 変更を revert すれば、従来の挙動に戻せます。