### PR TITLE
[codex] Secrets Manager の実値管理を AWS 側へ分離

### DIFF
--- a/.github/workflows/infra-terraform.yml
+++ b/.github/workflows/infra-terraform.yml
@@ -51,11 +51,10 @@ jobs:
           TF_CONTAINER_PORT: ${{ vars.TF_CONTAINER_PORT }}
           TF_PUBLIC_INGRESS_CIDRS: ${{ vars.TF_PUBLIC_INGRESS_CIDRS }}
           TF_SSM_PARAMETERS_JSON: ${{ vars.TF_SSM_PARAMETERS_JSON }}
-          TF_SECRETS_MANAGER_VALUES_JSON: ${{ secrets.TF_SECRETS_MANAGER_VALUES_JSON }}
         run: |
           missing=0
 
-          for name in AWS_CI_ROLE_ARN AWS_REGION TF_STATE_BUCKET TF_LOCK_TABLE TF_PROJECT_NAME TF_ENV TF_INSTANCE_TYPE TF_CONTAINER_PORT TF_PUBLIC_INGRESS_CIDRS TF_SSM_PARAMETERS_JSON TF_SECRETS_MANAGER_VALUES_JSON; do
+          for name in AWS_CI_ROLE_ARN AWS_REGION TF_STATE_BUCKET TF_LOCK_TABLE TF_PROJECT_NAME TF_ENV TF_INSTANCE_TYPE TF_CONTAINER_PORT TF_PUBLIC_INGRESS_CIDRS TF_SSM_PARAMETERS_JSON; do
             if [ -z "${!name}" ]; then
               echo "::error title=Missing GitHub configuration::$name is required for Terraform plan."
               missing=1
@@ -82,8 +81,7 @@ jobs:
             "instance_type": "${{ vars.TF_INSTANCE_TYPE }}",
             "container_port": ${{ vars.TF_CONTAINER_PORT }},
             "public_ingress_cidrs": ${{ vars.TF_PUBLIC_INGRESS_CIDRS }},
-            "ssm_parameters": ${{ vars.TF_SSM_PARAMETERS_JSON }},
-            "secrets_manager_values": ${{ secrets.TF_SECRETS_MANAGER_VALUES_JSON }}
+            "ssm_parameters": ${{ vars.TF_SSM_PARAMETERS_JSON }}
           }
           EOF
 
@@ -204,11 +202,10 @@ jobs:
           TF_CONTAINER_PORT: ${{ vars.TF_CONTAINER_PORT }}
           TF_PUBLIC_INGRESS_CIDRS: ${{ vars.TF_PUBLIC_INGRESS_CIDRS }}
           TF_SSM_PARAMETERS_JSON: ${{ vars.TF_SSM_PARAMETERS_JSON }}
-          TF_SECRETS_MANAGER_VALUES_JSON: ${{ secrets.TF_SECRETS_MANAGER_VALUES_JSON }}
         run: |
           missing=0
 
-          for name in AWS_CI_ROLE_ARN AWS_REGION TF_STATE_BUCKET TF_LOCK_TABLE TF_PROJECT_NAME TF_ENV TF_INSTANCE_TYPE TF_CONTAINER_PORT TF_PUBLIC_INGRESS_CIDRS TF_SSM_PARAMETERS_JSON TF_SECRETS_MANAGER_VALUES_JSON; do
+          for name in AWS_CI_ROLE_ARN AWS_REGION TF_STATE_BUCKET TF_LOCK_TABLE TF_PROJECT_NAME TF_ENV TF_INSTANCE_TYPE TF_CONTAINER_PORT TF_PUBLIC_INGRESS_CIDRS TF_SSM_PARAMETERS_JSON; do
             if [ -z "${!name}" ]; then
               echo "::error title=Missing GitHub configuration::$name is required for Terraform apply."
               missing=1
@@ -235,8 +232,7 @@ jobs:
             "instance_type": "${{ vars.TF_INSTANCE_TYPE }}",
             "container_port": ${{ vars.TF_CONTAINER_PORT }},
             "public_ingress_cidrs": ${{ vars.TF_PUBLIC_INGRESS_CIDRS }},
-            "ssm_parameters": ${{ vars.TF_SSM_PARAMETERS_JSON }},
-            "secrets_manager_values": ${{ secrets.TF_SECRETS_MANAGER_VALUES_JSON }}
+            "ssm_parameters": ${{ vars.TF_SSM_PARAMETERS_JSON }}
           }
           EOF
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 
 | 保存先 | 例 | 取り扱い |
 |---|---|---|
-| Secrets Manager | `DATABASE_URL`, `JWT_SECRET`, `SESSION_SECRET`, OAuth secret, API secret, webhook secret, private key, password/token | 漏洩時に重大事故へ直結する値 |
+| Secrets Manager | `DATABASE_URL`, `JWT_SECRET`, `SESSION_SECRET`, OAuth secret, API secret, webhook secret, private key, password/token | 漏洩時に重大事故へ直結する値。Terraform は secret の名前と ARN のみ管理し、値は AWS 側で登録する |
 | SSM Parameter Store | `APP_ENV`, `AWS_REGION`, `SITE_URL`, `LOG_LEVEL`, `CHAT_STORAGE_MODE`, 各種 table/bucket/queue 名 | 非機密の環境依存設定 |
 
 ## 初回 bootstrap 手順（Terraform apply）
@@ -131,9 +131,9 @@ Terraform 出力で以下を取得します。
 ### GitHub Secrets
 
 - `AWS_CI_ROLE_ARN`（bootstrap 出力 `github_actions_role_arn`）
-- `TF_SECRETS_MANAGER_VALUES_JSON`（JSON object 文字列）
 
 `infra-terraform.yml` はこれらの Variables / Secrets から `terraform.auto.tfvars.json` を組み立てて実行します。  
+`DATABASE_URL` / `JWT_SECRET` / `SESSION_SECRET` などの実値は GitHub に登録せず、AWS Secrets Manager で直接管理してください。
 ローカル apply を続けたい場合のみ、`infra/terraform/backend.hcl` と `infra/terraform/terraform.tfvars` をローカルに置いてください。
 
 ## 起動・停止・ログ・ロールバック

--- a/docs/architecture/init.md
+++ b/docs/architecture/init.md
@@ -57,7 +57,7 @@
 
 ### E. アプリ運用前提の未充足
 
-- `secrets_manager_values` のデフォルトが空文字（例: `DATABASE_URL`）で、実運用値投入が前提です。
+- Secrets Manager の secret value は Terraform 管理外のため、AWS Secrets Manager で実運用値の登録が必要です。
 - ECR にデプロイ対象イメージ（`:latest`）を push していない場合、サービスは正常稼働できません。
 - Terraform state バックエンド（S3 + DynamoDB lock）も未定義のため、チーム運用の衝突耐性が不足します。
 
@@ -109,13 +109,9 @@ cp terraform.tfvars.example terraform.tfvars
 
 最初に最低限チェックするキー:
 
-- `github_owner`, `github_repo`, `github_branch`
 - `ssm_parameters.SITE_URL`
-- `secrets_manager_values.DATABASE_URL`
-- `secrets_manager_values.JWT_SECRET`
-- `secrets_manager_values.SESSION_SECRET`
 
-> 注意: サンプル値（`replace-me` やダミー DB URL）のまま apply しないでください。
+Secrets Manager の実値は `terraform.tfvars` に書かず、AWS Secrets Manager で `DATABASE_URL` / `JWT_SECRET` / `SESSION_SECRET` を登録してください。
 
 ### ステップ 4: 前提不足を先に解消
 

--- a/docs/aws/terraform-ec2-oidc-ssm.md
+++ b/docs/aws/terraform-ec2-oidc-ssm.md
@@ -160,8 +160,8 @@ Repository の Settings で以下を設定します。
   - `TF_CONTAINER_PORT`
   - `TF_PUBLIC_INGRESS_CIDRS`（JSON 配列文字列）
   - `TF_SSM_PARAMETERS_JSON`（JSON object 文字列）
-- **Secrets**
-  - `TF_SECRETS_MANAGER_VALUES_JSON`（JSON object 文字列）
+
+Secrets Manager の実値（例: `DATABASE_URL`, `JWT_SECRET`, `SESSION_SECRET`）は GitHub Secrets に登録せず、AWS Secrets Manager で直接登録・更新します。Terraform は secret の名前、ARN、ECS task definition からの参照のみ管理します。
 
 ### 4-2. ワークフロー
 
@@ -169,6 +169,7 @@ Repository の Settings で以下を設定します。
   - `pull_request` で Terraform を `plan`
   - `push(main)` と `workflow_dispatch` で Terraform を `init/apply`
   - backend と tfvars は GitHub Variables / Secrets からその場で生成
+  - Secrets Manager の実値は Terraform 入力に含めない
   - 認証は `aws-actions/configure-aws-credentials@v6` + OIDC
 - `deploy-ec2-ssm.yml`
   - `push(main)` で SSM Run Command を実行

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -35,7 +35,7 @@ locals {
     key => value.arn
   }
 
-  secret_keys = toset(nonsensitive(keys(var.secrets_manager_values)))
+  secret_keys = var.secret_names
 
   common_tags = {
     Project = var.project_name
@@ -75,13 +75,6 @@ resource "aws_secretsmanager_secret" "app" {
   name                    = "${var.project_name}/${var.env}/${lower(each.value)}"
   recovery_window_in_days = 0
   tags                    = local.common_tags
-}
-
-resource "aws_secretsmanager_secret_version" "app" {
-  for_each = local.secret_keys
-
-  secret_id     = aws_secretsmanager_secret.app[each.value].id
-  secret_string = var.secrets_manager_values[each.value]
 }
 
 resource "aws_iam_role" "ecs_instance" {

--- a/infra/terraform/terraform.tfvars
+++ b/infra/terraform/terraform.tfvars
@@ -17,9 +17,3 @@ ssm_parameters = {
   CHAT_USER_QUEUE_TABLE    = "ChatUserQueue"
   CHAT_USER_QUEUE_PREFIX   = "chat-user"
 }
-
-secrets_manager_values = {
-  DATABASE_URL   = "postgresql://user:pass@host:5432/dbname"
-  JWT_SECRET     = "replace-me"
-  SESSION_SECRET = "replace-me"
-}

--- a/infra/terraform/terraform.tfvars.example
+++ b/infra/terraform/terraform.tfvars.example
@@ -17,9 +17,3 @@ ssm_parameters = {
   CHAT_USER_QUEUE_TABLE   = "ChatUserQueue"
   CHAT_USER_QUEUE_PREFIX  = "chat-user"
 }
-
-secrets_manager_values = {
-  DATABASE_URL   = "postgresql://user:pass@host:5432/dbname"
-  JWT_SECRET     = "replace-me"
-  SESSION_SECRET = "replace-me"
-}

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -72,13 +72,12 @@ variable "ssm_parameters" {
   }
 }
 
-variable "secrets_manager_values" {
-  description = "Secret runtime values stored in AWS Secrets Manager"
-  type        = map(string)
-  sensitive   = true
-  default = {
-    DATABASE_URL   = ""
-    JWT_SECRET     = ""
-    SESSION_SECRET = ""
-  }
+variable "secret_names" {
+  description = "Runtime secret names created in AWS Secrets Manager. Secret values are managed outside Terraform."
+  type        = set(string)
+  default = [
+    "DATABASE_URL",
+    "JWT_SECRET",
+    "SESSION_SECRET",
+  ]
 }


### PR DESCRIPTION
### 1) 実装・修正内容
- Terraform から `secrets_manager_values` 変数を削除し、Secrets Manager の実値を Terraform 入力に含めない構成へ変更しました。
- `aws_secretsmanager_secret_version` の Terraform 管理を削除し、Terraform は secret の名前・ARN・ECS task definition 参照のみ管理するようにしました。
- `infra-terraform.yml` から `TF_SECRETS_MANAGER_VALUES_JSON` の必須チェックと `terraform.auto.tfvars.json` への出力を削除しました。
- README / docs の GitHub Secrets 登録手順を更新し、アプリ secret value は AWS Secrets Manager で直接管理する方針を明記しました。

### 2) 実装理由
- `DATABASE_URL` / `JWT_SECRET` / `SESSION_SECRET` などの実値を GitHub Actions runner、Terraform input、Terraform state に通さないためです。
- 方針 4「AWS に最小コストでデプロイする」を維持しつつ、既存の Secrets Manager / ECS task definition `secrets` 構成を活かしてセキュリティを改善しました。
- 方針 1「Next.js の最新設計」および方針 2「SEO / AEO」はアプリコード未変更のため維持しています。
- 比較案として GitHub Secret `TF_SECRETS_MANAGER_VALUES_JSON` から Terraform で `secret_string` を登録する方法がありますが、Terraform state に secret value が残るリスクがあるため採用しませんでした。

### 3) 変更ファイル
- `.github/workflows/infra-terraform.yml`: Terraform workflow から secret value 入力を削除。
- `infra/terraform/variables.tf`: secret value 変数を削除し、secret 名のみを管理する `secret_names` に変更。
- `infra/terraform/main.tf`: `aws_secretsmanager_secret_version` を削除し、secret 本体のみ Terraform 管理に変更。
- `infra/terraform/terraform.tfvars`: ローカル tfvars から secret value サンプルを削除。
- `infra/terraform/terraform.tfvars.example`: example から secret value サンプルを削除。
- `README.md`: GitHub Secrets と Secrets Manager の責務を更新。
- `docs/aws/terraform-ec2-oidc-ssm.md`: GitHub Actions 運用手順を更新。
- `docs/architecture/init.md`: 初期構成メモの secret value 管理方針を更新。

### 4) 動作確認
```bash
terraform -chdir=infra/terraform fmt -check -recursive
# PASS
```

```bash
npm run lint
# PASS
```

```bash
npm run build
# PASS
```

```bash
terraform -chdir=infra/terraform validate
# PASS
```

```bash
git diff --check
# PASS
```

```bash
npm run typecheck
# FAIL: package.json に typecheck script が存在しないため実行不可
```

手動確認:
- `TF_SECRETS_MANAGER_VALUES_JSON` / `secrets_manager_values` / `aws_secretsmanager_secret_version` の参照が `.github`, `infra`, `README.md`, `docs` から削除されていることを確認しました。

### 5) 影響範囲
- Next.js 最新設計への整合性: 影響なし。アプリコードと App Router 構成は未変更です。
- SEO 影響: 影響なし。metadata / JSON-LD / sitemap / robots 関連コードは未変更です。
- リアルタイムチャット機能への影響: 影響なし。チャット API / SSE 実装は未変更です。
- AWS コスト影響（増減見込み）: なし。Secrets Manager の secret 本体は従来どおりで、追加リソースはありません。

### 6) 提案・懸念点
- 既に `TF_SECRETS_MANAGER_VALUES_JSON` 経由で apply 済みの場合、過去の Terraform state / S3 state version に secret value が残っている可能性があります。
- main マージ後は GitHub Secret `TF_SECRETS_MANAGER_VALUES_JSON` を削除し、AWS Secrets Manager 側で `DATABASE_URL` / `JWT_SECRET` / `SESSION_SECRET` の実値登録とローテーションを行うことを推奨します。
- `terraform plan` では `aws_secretsmanager_secret_version.app` の管理解除差分が出る想定です。secret 本体削除差分が出た場合は apply 前に確認してください。

### 7) リスクとロールバック
- リスク: Secrets Manager の実値が未登録または空の場合、ECS タスク起動時にアプリが必要な環境変数を取得できません。
- リスク: 過去 state に残った secret value は今回のコード変更だけでは削除されません。
- ロールバック: 必要な場合は `secrets_manager_values` と `aws_secretsmanager_secret_version` 管理を戻し、GitHub Secret `TF_SECRETS_MANAGER_VALUES_JSON` を再登録します。ただし Terraform state に secret value が残るため、推奨はしません。