### PR TITLE
Make `/search` honor filters, add conservative metadata, and fix nested `<main>` landmark

### DIFF
--- a/app/(store)/search/page.tsx
+++ b/app/(store)/search/page.tsx
@@ -1,40 +1,116 @@
 import type { Metadata } from 'next';
 import { ProductCard } from '@/components/ProductCard';
 import { Breadcrumbs } from '@/components/seo/Breadcrumbs';
-import { searchProducts } from '@/data/products';
+import {
+  PRODUCT_CATEGORIES,
+  getCategoryLabel,
+  searchProducts,
+  type DigitalCategory,
+  type ProductSearchFilters
+} from '@/data/products';
 import { buildSearchMetadata } from '@/lib/seo/metadata';
 
 type Props = {
   searchParams: Promise<Record<string, string | string[] | undefined>>;
 };
 
+const FILTER_KEYS = ['q', 'category', 'tag', 'priceMin', 'priceMax', 'sort'] as const;
+const SORT_LABELS: Record<NonNullable<ProductSearchFilters['sort']>, string> = {
+  newest: '新着順',
+  price_asc: '価格の安い順',
+  price_desc: '価格の高い順'
+};
+
 function readValue(value: string | string[] | undefined) {
   return Array.isArray(value) ? value[0] : value;
 }
 
-function buildSearchCanonical(params: Record<string, string | string[] | undefined>) {
-  const q = readValue(params.q);
-
-  if (!q) {
-    return '/search';
+function parsePrice(value: string | undefined) {
+  if (!value) {
+    return undefined;
   }
 
-  const query = new URLSearchParams({ q });
-  return `/search?${query.toString()}`;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined;
+}
+
+function parseSort(value: string | undefined): ProductSearchFilters['sort'] {
+  return value === 'price_asc' || value === 'price_desc' || value === 'newest' ? value : 'newest';
+}
+
+function parseFilters(params: Record<string, string | string[] | undefined>): ProductSearchFilters {
+  return {
+    query: readValue(params.q)?.trim() || undefined,
+    category: readValue(params.category)?.trim() || undefined,
+    tag: readValue(params.tag)?.trim() || undefined,
+    priceMin: parsePrice(readValue(params.priceMin)),
+    priceMax: parsePrice(readValue(params.priceMax)),
+    sort: parseSort(readValue(params.sort))
+  };
+}
+
+function hasSearchParameters(params: Record<string, string | string[] | undefined>) {
+  return FILTER_KEYS.some((key) => Boolean(readValue(params[key])?.trim()));
+}
+
+function buildSearchCanonical(params: Record<string, string | string[] | undefined>) {
+  const query = new URLSearchParams();
+
+  FILTER_KEYS.forEach((key) => {
+    const value = readValue(params[key])?.trim();
+    if (value) {
+      query.set(key, value);
+    }
+  });
+
+  return query.toString() ? `/search?${query.toString()}` : '/search';
+}
+
+function buildActiveFilterLabels(filters: ProductSearchFilters) {
+  const labels: string[] = [];
+
+  if (filters.query) {
+    labels.push(`キーワード「${filters.query}」`);
+  }
+
+  if (filters.category) {
+    const category = filters.category as DigitalCategory;
+    const categoryLabel = PRODUCT_CATEGORIES.includes(category) ? getCategoryLabel(category) : filters.category;
+    labels.push(`カテゴリ「${categoryLabel}」`);
+  }
+
+  if (filters.tag) {
+    labels.push(`タグ「${filters.tag}」`);
+  }
+
+  if (typeof filters.priceMin === 'number') {
+    labels.push(`${filters.priceMin.toLocaleString('ja-JP')}円以上`);
+  }
+
+  if (typeof filters.priceMax === 'number') {
+    labels.push(`${filters.priceMax.toLocaleString('ja-JP')}円以下`);
+  }
+
+  labels.push(`並び替え「${SORT_LABELS[filters.sort ?? 'newest']}」`);
+
+  return labels;
 }
 
 export async function generateMetadata({ searchParams }: Props): Promise<Metadata> {
   const params = await searchParams;
 
-  return buildSearchMetadata(buildSearchCanonical(params));
+  return buildSearchMetadata(buildSearchCanonical(params), {
+    robots: hasSearchParameters(params) ? { index: false, follow: true } : undefined
+  });
 }
 
 export default async function SearchPage({ searchParams }: Props) {
   const params = await searchParams;
-  const q = readValue(params.q) ?? '';
+  const filters = parseFilters(params);
   const canonical = buildSearchCanonical(params);
+  const activeFilterLabels = buildActiveFilterLabels(filters);
 
-  const items = searchProducts({ query: q, sort: 'newest' });
+  const items = searchProducts(filters);
 
   return (
     <main>
@@ -45,9 +121,10 @@ export default async function SearchPage({ searchParams }: Props) {
         ]}
       />
       <h1>検索結果</h1>
-      <p>キーワード: {q || '未入力'}</p>
+      <p className="products-count">Search results ({items.length})</p>
+      <p>適用中の条件: {activeFilterLabels.join(' / ')}</p>
       {items.length === 0 ? (
-        <p>検索結果がありませんでした。別キーワードをお試しください。</p>
+        <p className="empty-state">条件に一致する商品がありません。キーワードや価格などの検索条件を調整してください。</p>
       ) : (
         <section className="grid" aria-label="検索結果商品一覧">
           {items.map((product) => (

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -38,7 +38,7 @@ export default async function RootLayout({
         <SkipLink />
         <SiteHeader currentUser={currentUser} />
 
-        <main id="main">{children}</main>
+        <div id="main">{children}</div>
 
         <SiteFooter />
       </body>

--- a/docs/ai/output/decision-reviewer/001-improvement-decisions.md
+++ b/docs/ai/output/decision-reviewer/001-improvement-decisions.md
@@ -1,0 +1,184 @@
+1. Decision summary
+
+- Accept **Option A** with a narrow scope: make `/search` honor existing product filter query parameters (`q`, `category`, `tag`, `priceMin`, `priceMax`, `sort`) by reusing the existing product search/filter model, and keep filtered search pages conservative for SEO with `noindex,follow`.
+- Accept **Option C** with a narrow scope: remove nested `<main>` landmarks while preserving the skip-link target and page-level main landmarks.
+- Defer **Option B** for this cycle. It is valuable, but it introduces visible card-density/CSS risk and should follow the functional/search and semantic accessibility fixes.
+- Defer **Option D**. AEO FAQ/HowTo content may be useful, but it needs content strategy to avoid generic or thin templated pages.
+- Defer **Option E**. Chat architecture consolidation is important but larger and riskier than this cycle should be.
+- Reject no options outright. The non-accepted proposals are directionally compatible with the repository but should not be implemented in this narrow pass.
+
+2. Accepted items
+
+- Item label: **Option A — Fix `/search` filters and canonicalization**
+  - Scope to implement:
+    - Update `/search` so it parses and applies the existing filter query parameters:
+      - `q`
+      - `category`
+      - `tag`
+      - `priceMin`
+      - `priceMax`
+      - `sort`
+    - Reuse the repository’s existing product filtering/search logic where practical instead of creating a separate search implementation.
+    - Ensure home page price shortcut links such as `/search?priceMin=...` produce matching filtered results.
+    - Update search page headings, empty-state copy, and/or result summary so the applied filters are understandable to users.
+    - Canonicalization/robots decision:
+      - Treat parameterized search results as utility/result pages rather than primary SEO landing pages.
+      - Use `robots: { index: false, follow: true }` for filtered/search-result parameter pages, especially when query/filter parameters are present.
+      - Avoid creating indexable thin combinations of arbitrary search parameters.
+    - Preserve existing behavior for plain `/search` and `/search?q=...` where possible, while making the SEO handling explicit and conservative.
+  - Acceptance rationale:
+    - Fixes a clear user-facing mismatch identified in the proposal: home price shortcuts point to `/search?priceMin=...`, but `/search` currently ignores price filters.
+    - Aligns with ecommerce UX by making discovery links truthful and useful.
+    - Aligns with SEO/AEO by avoiding misleading result pages and reducing duplicate/thin indexed URL risk.
+    - Low implementation cost and reversible.
+    - Builds on existing product filtering capabilities instead of introducing a new architecture.
+
+- Item label: **Option C — Remove nested `<main>` landmarks**
+  - Scope to implement:
+    - Eliminate nested `<main>` landmarks caused by the root layout and page components both rendering `<main>`.
+    - Prefer the smaller convention change:
+      - Root layout should keep the skip-link target but use a non-landmark wrapper such as `<div id="main">` or equivalent.
+      - Page components should continue owning their page-level `<main>` landmarks.
+    - Preserve skip-link behavior.
+    - Confirm key route groups still expose a meaningful main landmark at the page level.
+    - Avoid broad conversion of every page component unless necessary.
+  - Acceptance rationale:
+    - Addresses a concrete accessibility/semantic HTML issue with low code risk.
+    - Supports machine-readable page structure, which indirectly helps SEO/AEO quality.
+    - The change is small, reversible, and consistent with modern App Router layouts where the root layout owns shell elements while pages define page content landmarks.
+    - Avoids a broader and riskier “layout owns all main landmarks” refactor.
+
+3. Rejected items
+
+- None.
+
+4. Deferred items
+
+- Item label: **Option B — Upgrade `ProductCard` with richer visible product attributes**
+  - Deferral rationale:
+    - Directionally valuable for ecommerce UX and AEO, but it is a visible design/CSS change affecting many grids across the app.
+    - The current cycle should prioritize correcting broken/misleading filter behavior and semantic accessibility first.
+    - Card-density decisions require product/design judgment: which fields matter most, whether cards need compact/default variants, and how much information is appropriate on home versus listing pages.
+  - Information needed to revisit:
+    - Desired card density per surface: home, product listing, related products, ranking/search/category/tag pages.
+    - Priority fields: category, tags, file format, license, seller rating, favorites, sales count, instant-download badge.
+    - Whether tags/categories inside cards should be links or plain labels to avoid nested-interactive complexity.
+    - Visual acceptance criteria or screenshots for responsive card layout.
+
+- Item label: **Option D — Add AEO FAQ/HowTo blocks to category and tag detail pages**
+  - Deferral rationale:
+    - The repository already has strong SEO/AEO foundations; adding templated content without a content plan risks thin or repetitive pages.
+    - FAQ JSON-LD should only be added when the FAQ content is visible and genuinely useful.
+    - This is medium-cost and content-sensitive, making it less suitable for the current small implementation cycle.
+  - Information needed to revisit:
+    - Which landing pages are highest priority: category pages, tag pages, or both.
+    - Human-approved FAQ/HowTo content guidelines.
+    - Whether content should be data-driven from a central SEO content module or authored page-by-page.
+    - Indexing strategy for category/tag pages with generated content.
+
+- Item label: **Option E — Consolidate or document chat abstractions**
+  - Deferral rationale:
+    - Chat is important to the repository direction, but the proposal indicates multiple generations of chat code, which raises discovery and regression risk.
+    - Code consolidation could accidentally break existing chat/admin monitor flows.
+    - This cycle should avoid medium/high-risk architecture cleanup while addressing clearer frontend UX/SEO/A11y issues.
+  - Information needed to revisit:
+    - Confirm the canonical active chat path: likely `lib/chat/core/*` and `/chat/[conversationId]`, but this needs verification.
+    - Decide whether older repository/SSE/SQS modules are legacy, future AWS preparation, or still active.
+    - Define the production real-time target: in-memory demo, SSE, WebSocket, SQS-backed worker, or another AWS-minimal architecture.
+    - Establish chat regression tests or manual QA steps before refactoring.
+
+- Item label: **Defer AWS deployment and broad real-time backend rewrites**
+  - Deferral rationale:
+    - No accepted item requires infrastructure changes.
+    - AWS work can increase cost and operational complexity without immediate product value in this cycle.
+    - Broad real-time backend rewrites are not small or easily reversible.
+  - Information needed to revisit:
+    - Deployment target and budget ceiling.
+    - Expected concurrent users and real-time latency requirements.
+    - Persistence requirements for chat.
+    - Monitoring and failure-mode expectations.
+
+5. Reasoning
+
+- Repository priorities considered:
+  - **Modern Next.js architecture**:
+    - Option A should reuse existing App Router conventions, metadata patterns, and product filtering types.
+    - Option C improves semantic layout structure without a broad architecture rewrite.
+  - **SEO / AEO quality**:
+    - Option A corrects search-result behavior while preventing uncontrolled indexing of thin parameter combinations.
+    - Option C improves landmark semantics and machine-readable structure.
+    - Option D is SEO/AEO-oriented but should wait for stronger content guidance.
+  - **Ecommerce UX**:
+    - Option A directly improves the user journey from home page price shortcuts to relevant results.
+    - Option B would improve browsing quality but is more visual and should be scoped carefully later.
+  - **Real-time chat capability**:
+    - Option E relates to chat maintainability, but it is not necessary for the accepted search/accessibility fixes.
+    - Avoiding chat refactors in this cycle reduces regression risk.
+  - **Minimum AWS cost**:
+    - Accepted items require no AWS resources and do not increase hosting complexity.
+    - AWS and real-time backend work should remain deferred until requirements are clearer.
+  - **Learning value**:
+    - Option A demonstrates safe reuse of existing domain filters and conservative SEO handling for search-result pages.
+    - Option C demonstrates accessible landmark conventions in a Next.js App Router app.
+
+- Cost / risk / reversibility notes:
+  - **Option A**:
+    - Cost: Low.
+    - Risk: Moderate SEO risk if search/filter URLs are made indexable indiscriminately.
+    - Mitigation: use `noindex,follow` for parameterized search-result pages and keep canonical behavior conservative.
+    - Reversibility: High.
+  - **Option C**:
+    - Cost: Low.
+    - Risk: Low, mainly skip-link behavior and route coverage.
+    - Mitigation: preserve `id="main"` target and validate rendered pages still include page-level `<main>`.
+    - Reversibility: High.
+  - **Option B**:
+    - Cost: Low to Medium.
+    - Risk: Visual density and cross-page CSS regression.
+    - Reversibility: Medium.
+  - **Option D**:
+    - Cost: Medium.
+    - Risk: Thin/repetitive content and structured-data quality issues.
+    - Reversibility: Medium.
+  - **Option E**:
+    - Cost: Medium to High.
+    - Risk: Chat regression due to overlapping active/legacy abstractions.
+    - Reversibility: Lower if migrations are attempted.
+
+6. Implementation handoff for implementer
+
+- Only accepted items:
+  - Implement **Option A**:
+    - Inspect existing `/products` filter parsing and `searchProducts` / `ProductSearchFilters` utilities.
+    - Update `/search` to parse `q`, `category`, `tag`, `priceMin`, `priceMax`, and `sort`.
+    - Ensure invalid numeric values are ignored or safely normalized.
+    - Ensure result count/heading/empty state reflects active filters.
+    - Add or update metadata so parameterized search result pages are not indexed:
+      - Use `robots: { index: false, follow: true }` when search/filter parameters are present.
+      - Keep canonical URLs conservative and avoid generating indexable arbitrary filter combinations.
+    - Confirm home page price shortcut URLs now produce filtered search results.
+  - Implement **Option C**:
+    - Change the root layout’s outer content wrapper from `<main id="main">` to a non-landmark skip target, likely `<div id="main">`.
+    - Preserve the skip link target and keyboard behavior.
+    - Confirm page-level routes still render their own `<main>`.
+    - Do not perform a large page-wide landmark refactor unless a specific route lacks a main landmark and can be fixed minimally.
+
+- Explicit non-goals:
+  - Do not implement ProductCard visual-density upgrades in this cycle.
+  - Do not add category/tag FAQ or HowTo content blocks in this cycle.
+  - Do not consolidate chat repositories, SSE, SQS, or `lib/chat/core` implementations in this cycle.
+  - Do not add AWS resources or deployment changes.
+  - Do not introduce a new search backend or duplicate the product filtering system.
+  - Do not make arbitrary parameterized `/search` pages indexable SEO landing pages.
+
+- Suggested validation commands or checks:
+  - `npm run lint`
+  - `npm run build`
+  - If available, run the repository’s type/check script, for example `npm run typecheck` or `npm run check`.
+  - Manual checks:
+    - Visit `/search?priceMin=3000` and confirm results are price-filtered.
+    - Visit `/search?priceMax=2000` and confirm results are price-filtered.
+    - Visit `/search?q=<known keyword>&category=<known category>&sort=price-asc` and confirm combined filtering/sorting works.
+    - Inspect rendered HTML for a representative store page and confirm there is no nested `<main>`.
+    - Confirm the skip link still moves focus/scroll target to the main content area.
+    - Confirm parameterized search pages include conservative robots metadata such as `noindex,follow`.

--- a/docs/ai/output/implementer/001-implementation-result.md
+++ b/docs/ai/output/implementer/001-implementation-result.md
@@ -1,0 +1,55 @@
+1. Accepted scope implemented
+
+- Implemented **Option A — Fix `/search` filters and canonicalization**.
+  - `/search` now parses `q`, `category`, `tag`, `priceMin`, `priceMax`, and `sort` from `searchParams`.
+  - The page reuses `searchProducts` and `ProductSearchFilters` for filtering and sorting.
+  - Invalid, negative, or non-finite numeric price values are ignored during filtering.
+  - The result count, visible active-condition summary, and empty-state copy now reflect applied filters.
+  - Parameterized search pages now pass `robots: { index: false, follow: true }` to search metadata.
+  - Search canonical URLs remain conservative and include only supported search/filter parameters.
+- Implemented **Option C — Remove nested `<main>` landmarks**.
+  - The root layout wrapper was changed from `<main id="main">` to `<div id="main">`.
+  - The skip-link target remains `#main`.
+  - Page-level routes continue to own their `<main>` landmarks.
+
+2. Files changed and why
+
+- `app/(store)/search/page.tsx`
+  - Added scoped query-parameter parsing for supported search filters.
+  - Added safe price normalization and sort normalization.
+  - Reused existing product search/filter data model to return filtered results.
+  - Added visible active-filter labels, result count, and improved empty-state copy.
+  - Added noindex/follow robots metadata for parameterized search-result URLs.
+- `lib/seo/metadata.ts`
+  - Extended `buildSearchMetadata` with an optional robots metadata argument so `/search` can keep conservative SEO handling for utility result pages.
+- `app/layout.tsx`
+  - Changed the root skip target wrapper to a non-landmark `<div id="main">` to avoid nesting page-level `<main>` landmarks.
+
+3. Behavior changes
+
+- `/search?priceMin=3000` now filters out products below 3,000円 instead of returning unfiltered keyword-only results.
+- `/search?priceMax=2000` now filters to products at or below 2,000円.
+- `/search?q=<keyword>&category=<category>&tag=<tag>&priceMin=<number>&priceMax=<number>&sort=<sort>` now applies supported filters together through the existing `searchProducts` utility.
+- Unsupported or invalid price values are ignored safely instead of becoming `NaN` filters.
+- Parameterized `/search` pages emit conservative robots metadata (`noindex,follow`) while preserving supported parameters in canonical metadata.
+- The root layout no longer creates a nested main landmark around pages that already render `<main>`.
+
+4. Validation commands run or recommended
+
+- Ran `npm run lint` successfully.
+- Ran `npm run build` successfully.
+- Recommended manual checks for the next reviewer:
+  - Visit `/search?priceMin=3000` and confirm only products priced at 3,000円以上 are listed.
+  - Visit `/search?priceMax=2000` and confirm no higher-priced products are listed.
+  - Visit `/search?q=photo&category=photo&sort=price_asc` and confirm combined filtering/sorting works.
+  - Inspect a rendered store route and confirm there is no root `<main>` wrapping a page-level `<main>`.
+  - Confirm the skip link still targets `#main`.
+
+5. Known follow-ups that were intentionally not implemented
+
+- Did not implement ProductCard visual-density upgrades.
+- Did not add category/tag FAQ or HowTo content blocks.
+- Did not consolidate chat implementations.
+- Did not add AWS or deployment changes.
+- Did not introduce a new search backend.
+- Did not make arbitrary parameterized `/search` pages indexable SEO landing pages.

--- a/docs/ai/output/improvement-proposer/001-improvement-proposals.md
+++ b/docs/ai/output/improvement-proposer/001-improvement-proposals.md
@@ -1,0 +1,139 @@
+1. Context observed
+
+- Repository is a Next.js App Router ecommerce app using Next.js 15.1.6, React 19, TypeScript, and npm scripts for `build`, `lint`, and CI checks.
+- The app already has several modern App Router patterns:
+  - Route groups under `app/(store)` and `app/(admin)`.
+  - Async `searchParams` / `params` usage compatible with current Next.js conventions.
+  - `generateMetadata`, `generateStaticParams`, sitemap, robots, Open Graph, Twitter metadata, Product JSON-LD, FAQ JSON-LD, and breadcrumbs.
+- Product discovery is already fairly developed:
+  - Home page includes hero search, featured products, new arrivals, categories, tags, price shortcuts, ranking-style UI explanation, and chat CTA.
+  - Product listing supports query/category/tag/price/sort filters at the data layer.
+  - Category and tag hub/detail pages exist and are included in sitemap.
+- Product detail already has:
+  - Product metadata and JSON-LD.
+  - FAQ JSON-LD.
+  - Seller summary.
+  - Add-to-cart, cart, terms, FAQ, and product-specific chat CTA.
+  - Related products.
+- Chat functionality exists in two generations/areas:
+  - `lib/chat/core/*` and `/chat/[conversationId]` appear to power the newer in-memory product-linked chat flow.
+  - Older-looking `lib/chat/repository.ts`, `sse-broker.ts`, `queue.ts`, and docs for SSE/SQS also exist.
+  - Product detail and chat list already connect product-specific chat sessions.
+- SEO/AEO foundations are strong, but there are still small gaps:
+  - Search page only canonicalizes and applies `q`; price shortcuts on home link to `/search?priceMin=...`, but `/search` currently ignores `priceMin` / `priceMax`.
+  - Product cards include Product microdata but only expose name and offer price; visible card content omits category, tags, license, file format, and immediate-download indicators even though the data model has these fields.
+  - Root layout wraps all pages in `<main id="main">`, while many pages also render their own `<main>`, creating nested main landmarks and potentially weaker accessibility semantics.
+- Repository documentation includes an existing UI enhancement proposal with phased ideas around home hierarchy, product cards, product detail, chat CTA, and minimal design-system work. Current implementation appears to have already addressed many Phase 1/2 items, so proposals should be incremental rather than broad rewrites.
+- Assumption: the next implementation cycle should be small, reviewable, and focused on visible product/SEO/A11y improvements rather than infrastructure rewrites.
+
+2. Improvement options
+
+- Option A
+  - Purpose: Fix `/search` so home price shortcuts and future filtered search URLs actually apply `priceMin`, `priceMax`, `category`, `tag`, and `sort`, and canonicalize those parameters consistently.
+  - Expected impact:
+    - Ecommerce UX: Users clicking “価格帯ショートカット” from home receive relevant filtered results instead of an unfiltered/keyword-only search page.
+    - SEO/AEO: Search/result pages can present clearer intent-specific headings/descriptions and avoid misleading canonical URLs. If parameterized search pages should not be indexed, this can also clarify robots behavior.
+    - Maintainability: Reuses the existing `ProductSearchFilters` shape and `searchProducts` filtering logic instead of maintaining a separate keyword-only search path.
+  - Implementation cost: Low
+  - Risks:
+    - If search result parameter pages are indexed accidentally, thin/duplicate pages may increase. Decision-reviewer should decide whether filtered `/search` pages should be `noindex,follow` or canonicalized to `/search`.
+    - Query parameter parsing is duplicated in `/products`; implementer should avoid excessive duplication if possible.
+  - Adoption decision points:
+    - Should `/search?q=...` and `/search?priceMin=...` be indexable, or should all search-result pages be `noindex,follow`?
+    - Should home price shortcuts continue pointing to `/search`, or should they point to `/products` because `/products` already has a full filter UI?
+    - Should `/search` remain a lightweight keyword landing page while `/products` becomes the canonical filtered listing?
+
+- Option B
+  - Purpose: Upgrade `ProductCard` to expose more decision-making information already available in `data/products.ts`: category label, first 2 tags, file format/license summary, seller rating or favorite count, and “即時DL” style badge.
+  - Expected impact:
+    - Ecommerce UX: Users can compare products without opening every detail page, improving discovery and likely click quality.
+    - SEO/AEO: Product cards can provide richer visible entity context around product type, license, format, and use cases. This helps both humans and AI answer engines understand page content.
+    - Accessibility: Better text labels and visible summaries reduce reliance on image/CTA alone.
+  - Implementation cost: Low to Medium
+  - Risks:
+    - Card density may become too high on home pages where many sections already exist.
+    - If microdata is expanded incorrectly, structured data quality could degrade. Keep visible content and structured data aligned.
+    - CSS changes may affect multiple grids across home, products, categories, tags, ranking, search, and related products.
+  - Adoption decision points:
+    - Which fields are highest priority on cards: category/tags/license/file format/rating/favorite count?
+    - Should home cards and listing cards share the same density, or should `ProductCard` accept a compact/default variant?
+    - Should tags on cards link to tag pages, or remain plain text to avoid nested interactive elements if the card has CTA links?
+
+- Option C
+  - Purpose: Remove nested `<main>` landmarks by changing the root layout wrapper from `<main id="main">` to a non-landmark skip-link target wrapper, or by standardizing page-level layout landmarks.
+  - Expected impact:
+    - Accessibility: Avoids multiple/nested main landmarks, making screen-reader navigation cleaner and more standards-aligned.
+    - Maintainability: Establishes a clear convention for App Router pages: layout owns header/footer and skip target; pages own their `<main>`.
+    - SEO/AEO: Better semantic HTML can marginally improve machine readability and page structure clarity.
+  - Implementation cost: Low
+  - Risks:
+    - Skip link currently likely targets `#main`; if the wrapper changes, the skip target must remain reliable.
+    - Some pages may not render `<main>` consistently; implementer should check route coverage before changing the layout.
+  - Adoption decision points:
+    - Should every page component own its `<main>`, with layout using `<div id="main">` or similar?
+    - Or should layout own the only `<main>` and page components be converted to sections/fragments? This is broader and less suitable for a small cycle.
+    - Should admin/chat pages follow the same convention now or be deferred?
+
+- Option D
+  - Purpose: Add lightweight AEO-focused FAQ/HowTo content blocks to category and tag detail pages using data-driven templates.
+  - Expected impact:
+    - SEO/AEO: Category/tag pages would better answer intent-specific questions like “商用利用できる写真素材を探すには？” or “BGM素材の形式は？” and become more useful landing pages.
+    - Ecommerce UX: Users arriving from organic search get clearer selection guidance before product grids.
+    - Learning value: Demonstrates scalable content modeling for category/tag landing pages without external CMS cost.
+  - Implementation cost: Medium
+  - Risks:
+    - Generic templated text can become thin or repetitive if overdone.
+    - FAQ JSON-LD should only be added when the FAQ is visible on the page.
+    - More content could push product grids lower on small screens.
+  - Adoption decision points:
+    - Start with category pages only, tag pages only, or both?
+    - Use visible FAQ sections only, or also add JSON-LD?
+    - Should content live in `data/products.ts`, a new SEO content module, or page-local constants?
+
+- Option E
+  - Purpose: Consolidate duplicated chat abstractions or clearly document current active chat path before deeper real-time/AWS implementation.
+  - Expected impact:
+    - Maintainability: Reduces ambiguity between `lib/chat/core/*` and older `lib/chat/*` repository/SSE/SQS modules.
+    - Realtime roadmap: Helps future implementers know whether to extend in-memory chat, repository-based chat, or AWS SQS/SSE design.
+    - AWS cost control: Prevents prematurely deploying multiple overlapping chat mechanisms.
+  - Implementation cost: Medium to High depending on whether it is documentation-only or code cleanup.
+  - Risks:
+    - Code cleanup could accidentally break current chat/admin monitor flows.
+    - Larger than ideal if implementer tries to migrate chat storage in the same cycle.
+  - Adoption decision points:
+    - Is this cycle meant to improve user-facing product pages, or invest in chat architecture hygiene?
+    - Should the accepted scope be documentation-only for now?
+    - Which chat implementation is considered canonical by the product owner?
+
+- Defer option
+  - Purpose: Defer infrastructure/AWS deployment changes and broad chat backend rewrites.
+  - Expected impact:
+    - Keeps the implementation cycle small and focused.
+    - Avoids costly or risky changes before UX/SEO basics are tightened.
+  - Implementation cost: Low
+  - Risks:
+    - Realtime chat and AWS deployment remain partially conceptual/documented rather than production-grade.
+  - Adoption decision points:
+    - Defer until after core ecommerce UX and semantic quality pass.
+    - Revisit once product owner prioritizes production deployment or real multi-user chat testing.
+
+3. Recommended decision-reviewer focus
+
+- Highest-priority recommendation: Accept Option A and Option C together if the goal is a small, safe implementation cycle.
+  - Option A fixes a clear user-facing mismatch: home price shortcuts currently imply filtered search behavior that `/search` does not implement.
+  - Option C fixes a semantic/accessibility issue with likely small code impact and low regression risk if skip-link behavior is preserved.
+- Secondary recommendation: Accept Option B if reviewer wants a visible ecommerce UX improvement in the same cycle and is comfortable with CSS/card snapshot risk.
+  - Keep B scoped to 3–4 high-value fields: category, first two tags, file format/license, and 即時DL badge.
+  - Avoid introducing a broad card variant system unless needed.
+- Recommended deferrals:
+  - Defer Option D unless content/SEO landing pages are the explicit priority for this cycle.
+  - Defer Option E unless the reviewer wants architecture cleanup rather than frontend UX/SEO improvements.
+  - Defer any AWS infrastructure or production realtime chat migration in this cycle.
+
+4. Open questions or assumptions for decision-reviewer
+
+- Should parameterized `/search` pages be indexable, or should filtered search pages use `robots: { index: false, follow: true }` to avoid thin/duplicate search result indexing?
+- Should home price shortcuts route to `/search` after fixing it, or to `/products` where filter UI already exists?
+- Is the current active chat implementation the `lib/chat/core/*` flow, and are older `lib/chat/repository.ts` / SSE/SQS modules retained for future AWS work?
+- For product cards, should seller trust metrics such as rating/sales/favorites be visible at card level, or reserved for product detail to keep cards calm?
+- Should the implementation cycle include visual CSS changes, or should it prioritize non-visual semantic/functionality fixes only?

--- a/docs/ai/output/product-review-packager/001-product-review-guide.md
+++ b/docs/ai/output/product-review-packager/001-product-review-guide.md
@@ -1,0 +1,190 @@
+1. Review summary
+
+- Status from quality review: **Ready with caveats**.
+- Implemented scope:
+  - `/search` now supports product filter query parameters: `q`, `category`, `tag`, `priceMin`, `priceMax`, and `sort`.
+  - Parameterized search result pages are treated conservatively for SEO with `noindex, follow`.
+  - Root layout no longer creates a nested `<main>` landmark; the skip-link target remains `#main`.
+- Main caveat:
+  - Search canonical URLs currently preserve raw invalid filter values such as `priceMin=-1` or `sort=invalid`, even though filtering logic ignores or normalizes those values.
+
+2. What changed
+
+- Search behavior:
+  - `/search` applies keyword, category, tag, price range, and sort filters through the existing product search/filter flow.
+  - Search pages now show:
+    - Result count.
+    - Active filter labels.
+    - Filter-aware empty-state copy.
+- SEO/AEO metadata behavior:
+  - `/search` without query/filter parameters remains the plain search page.
+  - `/search?...` with supported parameters receives conservative robots metadata: `noindex, follow`.
+  - Canonical paths are generated from supported query parameter names.
+- Accessibility/semantic layout:
+  - The root layout changed its skip-link target wrapper from a root `<main id="main">` to a non-landmark `<div id="main">`.
+  - Page components continue to own their own page-level `<main>` landmarks.
+
+3. Where to look
+
+## Screens / routes / URLs
+
+Use a local dev server or production preview and inspect these routes:
+
+- `/search`
+  - Baseline search page.
+- `/search?priceMin=3000`
+  - Confirms home price shortcut-style filtering now works.
+- `/search?priceMax=2000`
+  - Confirms maximum-price filtering.
+- `/search?q=素材&category=photo&sort=price_asc`
+  - Confirms combined keyword/category/sort filtering.
+- `/search?tag=商用利用&priceMin=1000&priceMax=5000&sort=price_desc`
+  - Confirms combined tag, price range, and descending price sort.
+- `/`
+  - Check that price shortcut links still navigate correctly.
+- Representative product/category/tag pages:
+  - Confirm there is no nested root `<main>` around page-level `<main>` content.
+
+## Components or flows
+
+- Search page:
+  - `app/(store)/search/page.tsx`
+- Root shell / skip-link target:
+  - `app/layout.tsx`
+- Search metadata helper:
+  - `lib/seo/metadata.ts`
+- Product filtering data flow:
+  - Existing `searchProducts` / `ProductSearchFilters` usage in `data/products.ts`.
+
+4. Verification steps
+
+1. Start the app locally.
+   - Suggested command: `npm run dev`
+2. Visit `/search?priceMin=3000`.
+   - Confirm all visible products are priced at or above 3,000円.
+   - Confirm the page displays an active filter label like `3,000円以上`.
+3. Visit `/search?priceMax=2000`.
+   - Confirm all visible products are priced at or below 2,000円.
+   - Confirm the page displays an active filter label like `2,000円以下`.
+4. Visit `/search?q=素材&category=photo&sort=price_asc`.
+   - Confirm the results are filtered by the keyword/category combination.
+   - Confirm results are sorted from lower price to higher price.
+   - Confirm active filter labels are understandable.
+5. Visit a query that should return no results.
+   - Example: `/search?q=zzzzzzzz&priceMin=999999`
+   - Confirm the empty state explains that no products match and suggests adjusting conditions.
+6. Inspect metadata for a parameterized search page.
+   - Confirm the page has conservative robots behavior such as `noindex, follow`.
+7. Inspect metadata for plain `/search`.
+   - Confirm it remains a normal canonical search page without filter-specific noindex behavior.
+8. Test the skip link.
+   - Use keyboard navigation from the top of the page.
+   - Activate the skip link.
+   - Confirm it targets `#main` and moves the user to the main content area.
+9. Inspect page landmarks.
+   - Confirm the root layout no longer wraps all routes in a root `<main>`.
+   - Confirm representative pages still expose a meaningful page-level `<main>`.
+
+5. Previous behavior vs latest behavior
+
+| Area | Previous behavior | Latest behavior |
+|---|---|---|
+| `/search?priceMin=3000` | Price parameter could be ignored by the search page. | Products are filtered using the minimum price. |
+| `/search?priceMax=2000` | Price parameter could be ignored by the search page. | Products are filtered using the maximum price. |
+| Combined filters | `/search` primarily behaved like keyword search. | `/search` supports keyword, category, tag, price range, and sort together. |
+| Search result explanation | Applied filters were less visible to users. | Result count and active filter labels are shown. |
+| Empty state | Empty results were less specific to filter conditions. | Empty state tells users to adjust keywords/prices/conditions. |
+| SEO for parameterized search | Search-result URL handling was less explicit. | Parameterized search pages use conservative `noindex, follow`. |
+| Layout landmarks | Root layout used `<main id="main">`, while pages also rendered `<main>`, creating nested main landmarks. | Root layout uses `<div id="main">`; pages own the main landmark. |
+
+6. Known unresolved issues
+
+- Low-severity SEO metadata caveat:
+  - Canonical URLs for `/search` are built from raw supported query parameter values.
+  - Invalid values are safely ignored or normalized for filtering, but can still appear in canonical metadata.
+  - Examples:
+    - `/search?priceMin=-1`
+      - Filtering treats `priceMin` as absent.
+      - Canonical may still include `priceMin=-1`.
+    - `/search?priceMax=abc`
+      - Filtering treats `priceMax` as absent.
+      - Canonical may still include `priceMax=abc`.
+    - `/search?sort=invalid`
+      - Filtering falls back to `newest`.
+      - Canonical may still include `sort=invalid`.
+- Impact:
+  - This does not block product review because filtering works and parameterized search pages are noindexed.
+  - It should be cleaned up in a future implementation cycle for metadata consistency and cleaner SEO hygiene.
+
+7. Decision points for the human reviewer
+
+- Search UX:
+  - Are the active filter labels clear enough for non-technical shoppers?
+  - Should the sort label always be displayed, even when it defaults to `newest`?
+  - Is the empty-state copy helpful enough when multiple filters produce no results?
+- SEO/AEO:
+  - Is `noindex, follow` the desired policy for all parameterized `/search` result pages?
+  - Should plain `/search?q=...` also remain noindexed, as currently intended for conservative search-result handling?
+  - Should future work normalize canonical URLs to remove invalid filter values?
+- Navigation:
+  - Should home price shortcuts continue linking to `/search`, or should they eventually point to `/products` if that becomes the primary filtered listing experience?
+- Accessibility:
+  - Is the skip-link behavior acceptable after changing the root wrapper to `<div id="main">`?
+  - Are there any pages where the page-level `<main>` landmark feels missing or poorly scoped?
+
+8. Human review checklist
+
+- [ ] `/search` loads normally without parameters.
+- [ ] `/search?priceMin=3000` returns only matching price-filtered products.
+- [ ] `/search?priceMax=2000` returns only matching price-filtered products.
+- [ ] Combined filters work with keyword, category, tag, price, and sort.
+- [ ] Result count matches visible product cards.
+- [ ] Active filter labels match the URL parameters.
+- [ ] Empty-state copy appears when no products match.
+- [ ] Parameterized search pages are not intended as indexable SEO landing pages.
+- [ ] Robots metadata for filtered/search-result pages is conservative.
+- [ ] Skip link still works with keyboard navigation.
+- [ ] Root layout no longer creates nested `<main>` landmarks.
+- [ ] No unintended ProductCard visual redesign is present.
+- [ ] No category/tag FAQ content was added in this cycle.
+- [ ] No chat architecture or AWS deployment changes were introduced.
+- [ ] Caveat about raw invalid canonical params is acceptable for this release or filed for follow-up.
+
+9. Suggested feedback format for the next improvement-proposer cycle
+
+```md
+## Product review result
+
+Decision:
+- Accept / Accept with follow-up / Request changes
+
+Reviewed routes:
+- /search
+- /search?priceMin=3000
+- /search?priceMax=2000
+- /search?q=素材&category=photo&sort=price_asc
+- Other:
+
+What worked well:
+- 
+
+Issues found:
+- 
+
+SEO/AEO feedback:
+- 
+
+Accessibility feedback:
+- 
+
+Follow-up priorities:
+1. 
+2. 
+3. 
+
+Should the next cycle address the known canonical caveat?
+- Yes / No / Later
+
+Additional notes:
+- 
+```

--- a/docs/ai/output/quality-reviewer/001-quality-review.md
+++ b/docs/ai/output/quality-reviewer/001-quality-review.md
@@ -1,0 +1,119 @@
+1. Review scope
+
+- Reviewed the latest implementation on commit `41f7e76` against the **decision-reviewer accepted scope only**:
+  - **Option A**: `/search` parses and applies `q`, `category`, `tag`, `priceMin`, `priceMax`, and `sort`; reuses existing product filtering; applies conservative `noindex,follow` metadata for parameterized search pages.
+  - **Option C**: root layout no longer creates nested `<main>` landmarks while preserving the skip-link target.
+- Reviewed changed files:
+  - `app/(store)/search/page.tsx`
+  - `app/layout.tsx`
+  - `lib/seo/metadata.ts`
+  - Saved subagent output docs were present in the commit, but not assessed as implementation behavior.
+- Validation commands run:
+  - `git status --short`
+  - `git log --oneline -5`
+  - `git show --stat --oneline HEAD`
+  - `git show --name-only --oneline HEAD`
+  - `sed -n '1,240p' 'app/(store)/search/page.tsx'`
+  - `sed -n '1,120p' app/layout.tsx`
+  - `sed -n '1,150p' lib/seo/metadata.ts`
+  - `rg "type ProductSearchFilters|function searchProducts|sort" data app components lib -n`
+  - `sed -n '1,260p' data/products.ts`
+  - `sed -n '1,130p' 'app/(store)/products/page.tsx'`
+  - `sed -n '1,120p' components/search/HomeSearchBar.tsx`
+  - `sed -n '1,80p' components/a11y/SkipLink.tsx`
+  - `find app -name 'page.tsx' -maxdepth 5 -print | sort | while read f; do if ! rg -q '<main' "$f"; then echo "NO_MAIN $f"; fi; done`
+  - `sed -n '1,180p' 'app/(store)/legal/LegalPageTemplate.tsx'`
+  - `npm run lint && npm run build`
+
+2. Findings by severity
+
+## Critical
+
+- None.
+
+## High
+
+- None.
+
+## Medium
+
+- None.
+
+## Low
+
+### Finding 1 — Search canonical URLs preserve unsupported or invalid raw filter values instead of normalized values
+
+- **Evidence**
+  - `parsePrice` safely ignores invalid, non-finite, or negative values for filtering.
+  - `parseSort` safely falls back unsupported sort values to `newest`.
+  - However, `buildSearchCanonical` independently copies raw non-empty values from `q`, `category`, `tag`, `priceMin`, `priceMax`, and `sort` into the canonical URL without applying the same normalization.
+  - Confirmed in `app/(store)/search/page.tsx`:
+    - `parsePrice(value)` returns `undefined` unless the value is finite and `>= 0`.
+    - `parseSort(value)` only accepts `price_asc`, `price_desc`, or `newest`.
+    - `buildSearchCanonical(params)` still uses raw trimmed query parameter values from `params`.
+  - Example confirmed by code inspection:
+    - `/search?priceMin=-1` would filter as if `priceMin` were absent, but canonicalize as `/search?priceMin=-1`.
+    - `/search?sort=unknown` would sort as `newest`, but canonicalize as `/search?sort=unknown`.
+
+- **Impact**
+  - This does **not** appear to break product filtering because filtering uses normalized values.
+  - SEO risk is limited because parameterized search pages are set to `noindex,follow`.
+  - Still, the accepted scope requested conservative canonicalization and safe normalization. Keeping invalid raw values in canonical URLs can create noisy, misleading canonical metadata and make manual QA/debugging harder.
+  - This is low severity because it is mostly metadata cleanliness for noindexed pages, not a user-facing functional failure.
+
+- **Recommended fix**
+  - Build canonical URLs from normalized filters instead of raw params.
+  - Alternatively, when constructing canonical params:
+    - Omit invalid `priceMin` / `priceMax`.
+    - Omit unsupported `sort`, or canonicalize it to `newest` only if the app intentionally wants `sort=newest` visible.
+    - Consider omitting unknown `category` values if they are not in `PRODUCT_CATEGORIES`, although this depends on whether future categories may be dynamic.
+
+- **Suggested validation**
+  - Add small unit coverage if test infrastructure exists, or manually inspect metadata output for:
+    - `/search?priceMin=-1`
+    - `/search?priceMax=abc`
+    - `/search?sort=invalid`
+    - `/search?priceMin=3000&sort=price_asc`
+  - Confirm invalid values are not preserved in canonical metadata while valid values are.
+
+3. For each finding
+
+- See the Low severity section above.
+
+4. Positive checks passed
+
+- `/search` now parses the accepted filter parameters:
+  - `q`
+  - `category`
+  - `tag`
+  - `priceMin`
+  - `priceMax`
+  - `sort`
+- `/search` reuses the existing `searchProducts(filters)` flow from `data/products.ts`, matching the accepted requirement to avoid a separate search implementation.
+- Invalid price values are safely normalized for filtering:
+  - Non-numeric, infinite, empty, and negative price params do not become active numeric filters.
+- Search result UI now exposes:
+  - Result count.
+  - Active filter labels.
+  - Filter-aware empty-state copy.
+- Parameterized search pages apply conservative robots metadata:
+  - `robots: { index: false, follow: true }` when supported search/filter params are present.
+- Plain `/search` remains indexable by default and canonicalizes to `/search`.
+- Root layout changed the skip-link target wrapper from `<main id="main">` to `<div id="main">`, eliminating the root-level landmark that previously caused nested `<main>` structures on pages that render their own main content.
+- The skip link still targets `#main`.
+- Route-level main landmark coverage appears acceptable:
+  - A quick scan flagged legal pages as not directly containing `<main>`, but their shared `LegalPageTemplate` renders `<main>`, so those pages still have page-level main landmarks.
+  - The legacy product route redirects and therefore does not need a rendered main landmark.
+- No evidence of scope drift:
+  - Deferred ProductCard visual-density upgrades were not implemented.
+  - Deferred category/tag FAQ/HowTo additions were not implemented.
+  - Deferred chat architecture consolidation was not implemented.
+  - No AWS/deployment changes were introduced.
+- Programmatic checks passed:
+  - `npm run lint` completed with no ESLint warnings or errors.
+  - `npm run build` completed successfully.
+
+5. Human-review readiness: **Ready with caveats**
+
+- The implementation satisfies the accepted functional and accessibility scope overall.
+- The only observed caveat is low severity: canonical URLs for `/search` are built from raw supported query parameter names rather than the normalized filter values used for actual search behavior. This should be cleaned up when convenient, but it does not block human product review because filtering works and parameterized search pages are noindexed.

--- a/lib/seo/metadata.ts
+++ b/lib/seo/metadata.ts
@@ -93,11 +93,15 @@ export function buildTagMetadata(tag: string): Metadata {
   });
 }
 
-export function buildSearchMetadata(canonicalPath: string): Metadata {
+export function buildSearchMetadata(
+  canonicalPath: string,
+  options?: { robots?: Metadata['robots'] }
+): Metadata {
   return buildMetadataTemplate({
     title: '検索結果',
     description: 'サイト内検索結果ページです。',
     canonicalPath,
+    robots: options?.robots
   });
 }
 


### PR DESCRIPTION
### Motivation

- Fix a user-facing mismatch where home price shortcuts linked to `/search?priceMin=...` but `/search` ignored price and other filter params, and improve accessibility by avoiding nested `<main>` landmarks.
- Keep the change small and reversible while preserving SEO/AEO hygiene by treating parameterized search results conservatively.

### Description

- Update `app/(store)/search/page.tsx` to parse and apply filter query parameters `q`, `category`, `tag`, `priceMin`, `priceMax`, and `sort`, reuse the existing `searchProducts` / `ProductSearchFilters` flow, normalize invalid numeric values, and surface result count, active filter labels, and a filter-aware empty state. (`app/(store)/search/page.tsx`)
- Add conservative canonical/robots behavior by passing `robots: { index: false, follow: true }` for parameterized search pages via a small `buildSearchMetadata` options extension in `lib/seo/metadata.ts`. (`lib/seo/metadata.ts`)
- Remove the root-level landmark to avoid nested `<main>` by changing the root wrapper from `<main id=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3960a06c5483288009a62d17984a82)