### PR TITLE
Search: parse filters, canonicalize params, mark filtered pages noindex; fix nested <main>

### DIFF
--- a/app/(store)/search/page.tsx
+++ b/app/(store)/search/page.tsx
@@ -1,40 +1,116 @@
 import type { Metadata } from 'next';
 import { ProductCard } from '@/components/ProductCard';
 import { Breadcrumbs } from '@/components/seo/Breadcrumbs';
-import { searchProducts } from '@/data/products';
+import {
+  PRODUCT_CATEGORIES,
+  getCategoryLabel,
+  searchProducts,
+  type DigitalCategory,
+  type ProductSearchFilters
+} from '@/data/products';
 import { buildSearchMetadata } from '@/lib/seo/metadata';
 
 type Props = {
   searchParams: Promise<Record<string, string | string[] | undefined>>;
 };
 
+const FILTER_KEYS = ['q', 'category', 'tag', 'priceMin', 'priceMax', 'sort'] as const;
+const SORT_LABELS: Record<NonNullable<ProductSearchFilters['sort']>, string> = {
+  newest: '新着順',
+  price_asc: '価格の安い順',
+  price_desc: '価格の高い順'
+};
+
 function readValue(value: string | string[] | undefined) {
   return Array.isArray(value) ? value[0] : value;
 }
 
-function buildSearchCanonical(params: Record<string, string | string[] | undefined>) {
-  const q = readValue(params.q);
-
-  if (!q) {
-    return '/search';
+function parsePrice(value: string | undefined) {
+  if (!value) {
+    return undefined;
   }
 
-  const query = new URLSearchParams({ q });
-  return `/search?${query.toString()}`;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined;
+}
+
+function parseSort(value: string | undefined): ProductSearchFilters['sort'] {
+  return value === 'price_asc' || value === 'price_desc' || value === 'newest' ? value : 'newest';
+}
+
+function parseFilters(params: Record<string, string | string[] | undefined>): ProductSearchFilters {
+  return {
+    query: readValue(params.q)?.trim() || undefined,
+    category: readValue(params.category)?.trim() || undefined,
+    tag: readValue(params.tag)?.trim() || undefined,
+    priceMin: parsePrice(readValue(params.priceMin)),
+    priceMax: parsePrice(readValue(params.priceMax)),
+    sort: parseSort(readValue(params.sort))
+  };
+}
+
+function hasSearchParameters(params: Record<string, string | string[] | undefined>) {
+  return FILTER_KEYS.some((key) => Boolean(readValue(params[key])?.trim()));
+}
+
+function buildSearchCanonical(params: Record<string, string | string[] | undefined>) {
+  const query = new URLSearchParams();
+
+  FILTER_KEYS.forEach((key) => {
+    const value = readValue(params[key])?.trim();
+    if (value) {
+      query.set(key, value);
+    }
+  });
+
+  return query.toString() ? `/search?${query.toString()}` : '/search';
+}
+
+function buildActiveFilterLabels(filters: ProductSearchFilters) {
+  const labels: string[] = [];
+
+  if (filters.query) {
+    labels.push(`キーワード「${filters.query}」`);
+  }
+
+  if (filters.category) {
+    const category = filters.category as DigitalCategory;
+    const categoryLabel = PRODUCT_CATEGORIES.includes(category) ? getCategoryLabel(category) : filters.category;
+    labels.push(`カテゴリ「${categoryLabel}」`);
+  }
+
+  if (filters.tag) {
+    labels.push(`タグ「${filters.tag}」`);
+  }
+
+  if (typeof filters.priceMin === 'number') {
+    labels.push(`${filters.priceMin.toLocaleString('ja-JP')}円以上`);
+  }
+
+  if (typeof filters.priceMax === 'number') {
+    labels.push(`${filters.priceMax.toLocaleString('ja-JP')}円以下`);
+  }
+
+  labels.push(`並び替え「${SORT_LABELS[filters.sort ?? 'newest']}」`);
+
+  return labels;
 }
 
 export async function generateMetadata({ searchParams }: Props): Promise<Metadata> {
   const params = await searchParams;
 
-  return buildSearchMetadata(buildSearchCanonical(params));
+  return buildSearchMetadata(buildSearchCanonical(params), {
+    robots: hasSearchParameters(params) ? { index: false, follow: true } : undefined
+  });
 }
 
 export default async function SearchPage({ searchParams }: Props) {
   const params = await searchParams;
-  const q = readValue(params.q) ?? '';
+  const filters = parseFilters(params);
   const canonical = buildSearchCanonical(params);
+  const activeFilterLabels = buildActiveFilterLabels(filters);
 
-  const items = searchProducts({ query: q, sort: 'newest' });
+  const items = searchProducts(filters);
 
   return (
     <main>
@@ -45,9 +121,10 @@ export default async function SearchPage({ searchParams }: Props) {
         ]}
       />
       <h1>検索結果</h1>
-      <p>キーワード: {q || '未入力'}</p>
+      <p className="products-count">Search results ({items.length})</p>
+      <p>適用中の条件: {activeFilterLabels.join(' / ')}</p>
       {items.length === 0 ? (
-        <p>検索結果がありませんでした。別キーワードをお試しください。</p>
+        <p className="empty-state">条件に一致する商品がありません。キーワードや価格などの検索条件を調整してください。</p>
       ) : (
         <section className="grid" aria-label="検索結果商品一覧">
           {items.map((product) => (

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -38,7 +38,7 @@ export default async function RootLayout({
         <SkipLink />
         <SiteHeader currentUser={currentUser} />
 
-        <main id="main">{children}</main>
+        <div id="main">{children}</div>
 
         <SiteFooter />
       </body>

--- a/docs/ai/output/decision-reviewer/001-improvement-decisions.md
+++ b/docs/ai/output/decision-reviewer/001-improvement-decisions.md
@@ -1,0 +1,131 @@
+1. 判断概要
+
+- **Option A** を narrow scope で Accepted とする。`/search` が既存の商品 filter query parameter (`q`, `category`, `tag`, `priceMin`, `priceMax`, `sort`) を扱い、既存の product search/filter model を再利用し、filtered search pages は `noindex, follow` で conservative に扱う。
+- **Option C** を narrow scope で Accepted とする。skip link target と page-level main landmark を維持しながら nested `<main>` landmark を解消する。
+- **Option B** は Deferred とする。価値はあるが、card density と CSS の visible risk があり、まず検索機能と semantic accessibility の修正を優先する。
+- **Option D** は Deferred とする。AEO FAQ/HowTo は有用だが、generic/thin content を避けるため content strategy が必要である。
+- **Option E** は Deferred とする。chat architecture の整理は重要だが、今回の cycle には大きく risk が高い。
+- outright rejection はなし。採用しなかった提案は repository の方向性とは一致するが、今回の narrow pass では実装しない。
+
+2. 採用項目
+
+- 項目ラベル: **Option A — `/search` の filters と canonicalization を修正**
+  - 実装 scope:
+    - `/search` で次の query parameter を解析し適用する。
+      - `q`
+      - `category`
+      - `tag`
+      - `priceMin`
+      - `priceMax`
+      - `sort`
+    - 可能な限り既存の商品 filter/search logic を再利用し、新しい検索実装を作らない。
+    - home page の価格帯ショートカット `/search?priceMin=...` が実際に filter 済み結果を返すようにする。
+    - 見出し、empty state、result summary などで適用中の条件が user に分かるようにする。
+    - parameterized search result pages は primary SEO landing page ではなく utility/result page として扱う。
+    - query/filter parameter がある場合は `robots: { index: false, follow: true }` を使う。
+    - arbitrary filter combination を indexable な thin page として生成しない。
+  - 採用理由:
+    - home の価格帯ショートカットが `/search?priceMin=...` を指しているのに `/search` が price filter を無視する、という明確な user-facing mismatch を修正する。
+    - ecommerce UX を改善し、探索導線を信頼できるものにする。
+    - SEO/AEO 上、duplicate/thin URL の index risk を抑えられる。
+    - 実装コストが低く、reversible である。
+
+- 項目ラベル: **Option C — nested `<main>` landmark の解消**
+  - 実装 scope:
+    - root layout と page component の双方が `<main>` を出すことによる nested landmark を解消する。
+    - 小さい convention change として、root layout は `<div id="main">` のような non-landmark skip target を使う。
+    - page component 側が page-level `<main>` landmark を持つ方針を維持する。
+    - skip link behavior を維持する。
+    - 必要以上に全 page を大規模 refactor しない。
+  - 採用理由:
+    - accessibility/semantic HTML の concrete issue を低 risk で修正できる。
+    - machine-readable page structure の改善により SEO/AEO 品質にも間接的に寄与する。
+    - 小さく reversible な変更である。
+
+3. 却下項目
+
+- なし。
+
+4. 延期項目
+
+- 項目ラベル: **Option B — ProductCard に richer visible product attributes を追加**
+  - Deferred 理由:
+    - ecommerce UX と AEO に価値はあるが、app 全体の grid に影響する visible design/CSS change である。
+    - 今回は broken/misleading filter behavior と semantic accessibility の修正を優先する。
+  - 再検討に必要な情報:
+    - surface ごとの card density 方針。
+    - 優先 field。
+    - card 内の category/tag を link にするか label にするか。
+    - responsive layout の visual acceptance criteria。
+
+- 項目ラベル: **Option D — category/tag detail pages に AEO FAQ/HowTo を追加**
+  - Deferred 理由:
+    - content plan なしの template content は thin/repetitive になり得る。
+    - FAQ JSON-LD は visible FAQ と一致させる必要がある。
+  - 再検討に必要な情報:
+    - 優先 landing pages。
+    - human-approved FAQ/HowTo content guideline。
+    - content の配置場所。
+
+- 項目ラベル: **Option E — chat abstraction の整理または文書化**
+  - Deferred 理由:
+    - 複数世代の chat code があり、discovery と regression risk が高い。
+    - 今回は frontend UX/SEO/A11y の明確な issue を優先する。
+  - 再検討に必要な情報:
+    - canonical active chat path。
+    - legacy/future AWS preparation/still active の切り分け。
+    - production realtime target。
+    - chat regression test / manual QA steps。
+
+- 項目ラベル: **AWS deployment と broad realtime backend rewrite の延期**
+  - Deferred 理由:
+    - accepted item は infrastructure 変更を必要としない。
+    - AWS 作業は cost と operational complexity を増やす可能性がある。
+
+5. 判断理由
+
+- Modern Next.js architecture:
+  - Option A は既存の App Router convention と product filtering type を再利用できる。
+  - Option C は broad architecture rewrite なしで semantic layout を改善する。
+- SEO / AEO:
+  - Option A は検索結果 URL の扱いを明確にし、thin parameter combination の uncontrolled indexing を避ける。
+  - Option C は landmark semantics を改善する。
+- Ecommerce UX:
+  - Option A は home 価格帯ショートカットから relevant results へつながる導線を改善する。
+- Real-time chat:
+  - Option E は重要だが、今回の検索/a11y 修正には不要である。
+- Minimum AWS cost:
+  - accepted items は AWS resource を追加しない。
+- Learning value:
+  - Option A は conservative SEO handling と既存 domain filter の再利用を学べる。
+  - Option C は App Router app における accessible landmark convention を学べる。
+
+6. implementer への 実装引き継ぎ
+
+- 実装する accepted item:
+  - **Option A**:
+    - 既存の `/products` filter parsing と `searchProducts` / `ProductSearchFilters` を確認する。
+    - `/search` で `q`、`category`、`tag`、`priceMin`、`priceMax`、`sort` を解析する。
+    - invalid numeric value は無視または安全に normalize する。
+    - result count、heading、empty state が active filters を反映するようにする。
+    - query/filter parameter がある検索結果ページには `robots: { index: false, follow: true }` を適用する。
+    - home price shortcut URL が filter 済み結果を返すことを確認する。
+  - **Option C**:
+    - root layout の wrapper を `<main id="main">` から non-landmark skip target、たとえば `<div id="main">` に変更する。
+    - skip link target と keyboard behavior を維持する。
+    - page-level routes が `<main>` を持つことを確認する。
+- 明示的な non-goals:
+  - ProductCard visual-density upgrade は実装しない。
+  - category/tag FAQ/HowTo は追加しない。
+  - chat repositories、SSE、SQS、`lib/chat/core` の整理はしない。
+  - AWS resource や deployment 変更はしない。
+  - 新しい search backend は導入しない。
+  - arbitrary parameterized `/search` を indexable SEO landing page にしない。
+- 推奨 validation:
+  - `npm run lint`
+  - `npm run build`
+  - `/search?priceMin=3000`
+  - `/search?priceMax=2000`
+  - `/search?q=<known keyword>&category=<known category>&sort=price_asc`
+  - 代表 page の HTML で nested `<main>` がないことを確認する。
+  - skip link が main content area へ移動することを確認する。

--- a/docs/ai/output/implementer/001-implementation-result.md
+++ b/docs/ai/output/implementer/001-implementation-result.md
@@ -1,0 +1,47 @@
+1. 実装した Accepted スコープ
+
+- **Option A — `/search` のフィルタと canonical を修正**を実装した。
+  - `/search` は `searchParams` から `q`、`category`、`tag`、`priceMin`、`priceMax`、`sort` を解析する。
+  - 既存の `searchProducts` と `ProductSearchFilters` を使って、絞り込みと並び替えを行う。
+  - 無効値、負数、非有限値の価格パラメータは検索条件として扱わない。
+  - 検索結果件数、適用中条件の表示、条件に応じた empty state を追加した。
+  - パラメータ付き検索ページでは `robots: { index: false, follow: true }` を検索 metadata に渡す。
+  - canonical URL は対応済み検索パラメータのみを使って生成する。
+- **Option C — nested `<main>` landmark の解消**を実装した。
+  - root layout のコンテンツラッパーを `<main id="main">` から `<div id="main">` に変更した。
+  - skip link の遷移先 `#main` は維持した。
+  - ページ単位の `<main>` landmark は各 page component 側に残した。
+
+2. 変更したファイルと理由
+
+- `app/(store)/search/page.tsx`
+  - 検索条件の解析、検索結果への適用、結果件数、適用中条件、empty state、検索 metadata 連携を追加するため。
+- `lib/seo/metadata.ts`
+  - 検索 metadata 生成時に robots 指定を渡せるようにするため。
+- `app/layout.tsx`
+  - root layout が全ページを `<main>` で包まないようにし、ページ側の `<main>` と nested landmark にならないようにするため。
+- `docs/ai/output/...`
+  - AGENTS.md の指示に従い、各 custom subagent の出力を保存するため。
+
+3. 振る舞いの変更
+
+- `/search?priceMin=3000` は、3,000円以上の商品だけを表示する。
+- `/search?priceMax=2000` は、2,000円以下の商品だけを表示する。
+- `/search?q=...&category=...&tag=...&sort=...` のような複合条件を既存の商品検索ロジックで処理する。
+- 検索ページには、結果件数と適用中条件が表示される。
+- 条件に一致する商品がない場合、検索条件の調整を促す empty state を表示する。
+- パラメータ付き `/search` は `noindex, follow` として扱う。
+- root layout は `<main>` landmark を作らず、ページ側の `<main>` と重複しない。
+
+4. 実行した検証コマンド
+
+- `npm run lint`
+- `npm run build`
+
+5. 意図的に実装しなかった既知の follow-up
+
+- ProductCard の情報量を増やす UI 改修は実装していない。
+- カテゴリ/タグページの FAQ や HowTo コンテンツ追加は実装していない。
+- chat 実装の統合や整理は実装していない。
+- AWS デプロイやインフラ変更は実装していない。
+- パラメータ付き `/search` を indexable な SEO landing page として扱う変更はしていない。

--- a/docs/ai/output/improvement-proposer/001-improvement-proposals.md
+++ b/docs/ai/output/improvement-proposer/001-improvement-proposals.md
@@ -1,0 +1,111 @@
+1. 観測した context
+
+- この repository は Next.js App Router の ecommerce app で、Next.js 15.1.6、React 19、TypeScript を利用している。
+- `app/(store)` と `app/(admin)` の route group、async `searchParams` / `params`、`generateMetadata`、`generateStaticParams`、sitemap、robots、Open Graph、Twitter metadata、Product JSON-LD、FAQ JSON-LD、breadcrumbs など、現代的な App Router 構成がすでに導入されている。
+- 商品発見導線は比較的充実している。
+  - home には hero search、featured products、new arrivals、categories、tags、価格帯ショートカット、ranking 風の説明 UI、chat CTA がある。
+  - product listing は data layer で query/category/tag/price/sort の filter に対応している。
+  - category と tag の hub/detail page があり、sitemap にも含まれている。
+- 商品詳細には metadata、JSON-LD、FAQ JSON-LD、seller summary、add-to-cart、cart、terms、FAQ、商品別 chat CTA、related products がある。
+- chat 機能は複数世代の実装が共存しているように見える。
+  - `lib/chat/core/*` と `/chat/[conversationId]` が新しい in-memory 商品連動 chat flow に見える。
+  - `lib/chat/repository.ts`、`sse-broker.ts`、`queue.ts`、SSE/SQS docs も残っている。
+- SEO/AEO の基盤は強いが、小さな gap がある。
+  - home の価格帯ショートカットは `/search?priceMin=...` へ遷移するが、`/search` は `priceMin` / `priceMax` を無視している。
+  - ProductCard は microdata を持つが、表示情報として category、tags、license、file format、即時 download などが不足している。
+  - root layout が `<main id="main">` で全ページを包み、各 page も `<main>` を持つため nested main landmark になり得る。
+- 今回の cycle は、大規模 rewrite ではなく、商品 UX / SEO / accessibility の小さく安全な改善に集中する前提で提案する。
+
+2. 改善 option
+
+- Option A
+  - 目的: `/search` が `priceMin`、`priceMax`、`category`、`tag`、`sort` を正しく扱い、home 価格帯ショートカットや将来の filtered search URL が意図通り動くようにする。
+  - 期待効果:
+    - ecommerce UX: 価格帯ショートカットを押した user が期待通りの検索結果を得られる。
+    - SEO/AEO: 検索結果ページの intent を明確にし、thin/duplicate な parameter URL の扱いを整理できる。
+    - maintainability: 既存の `ProductSearchFilters` と `searchProducts` を再利用できる。
+  - 実装コスト: 低
+  - リスク:
+    - parameterized search pages を indexable にすると thin/duplicate URL が増える可能性がある。
+    - `/products` と query parsing が重複しやすい。
+  - 採用判断点:
+    - filtered `/search` を indexable にするか、`noindex, follow` にするか。
+    - home の価格帯ショートカットを `/search` のままにするか、`/products` に寄せるか。
+
+- Option B
+  - 目的: `ProductCard` に category、上位 tags、file format/license、seller rating/favorite count、即時DL badge などを表示する。
+  - 期待効果:
+    - ecommerce UX: 商品詳細へ移動しなくても比較しやすくなる。
+    - SEO/AEO: 商品 entity の context が増え、human と AI engine の理解を助ける。
+  - 実装コスト: 低 to 中
+  - リスク:
+    - card density が上がり、home や listing の見た目に影響する。
+    - structured data と visible content の整合性に注意が必要。
+  - 採用判断点:
+    - どの field を card に出すか。
+    - home と listing で同じ密度にするか。
+    - tags/categories を link にするか plain label にするか。
+
+- Option C
+  - 目的: root layout と page component の nested `<main>` landmark を解消する。
+  - 期待効果:
+    - accessibility: screen reader の landmark navigation が明確になる。
+    - maintainability: layout は shell、page は main content という convention が明確になる。
+    - SEO/AEO: semantic HTML の構造が改善される。
+  - 実装コスト: 低
+  - リスク:
+    - skip link の target を維持する必要がある。
+    - page-level `<main>` がない route がないか確認が必要。
+  - 採用判断点:
+    - root は `<div id="main">` にして page 側が `<main>` を持つ方針にするか。
+    - 逆に layout が唯一の `<main>` を持つ方針にするか。
+
+- Option D
+  - 目的: category/tag detail page に AEO 向け FAQ/HowTo content block を追加する。
+  - 期待効果:
+    - SEO/AEO: category/tag page が intent-specific な質問に答えやすくなる。
+    - ecommerce UX: organic search から来た user が選び方を理解しやすくなる。
+  - 実装コスト: 中
+  - リスク:
+    - generic な template 文章が thin/repetitive content になり得る。
+    - FAQ JSON-LD は visible FAQ と一致させる必要がある。
+  - 採用判断点:
+    - category から始めるか、tag から始めるか、両方か。
+    - content をどこに持つか。
+
+- Option E
+  - 目的: chat abstraction の重複を整理するか、少なくとも active path を文書化する。
+  - 期待効果:
+    - maintainability: `lib/chat/core/*` と古い chat module の関係が明確になる。
+    - realtime roadmap: 今後どの implementation を伸ばすべきか判断しやすくなる。
+    - AWS cost control: 複数方式を同時に運用する無駄を避ける。
+  - 実装コスト: 中 to 高
+  - リスク:
+    - code cleanup は chat/admin monitor flow を壊す可能性がある。
+  - 採用判断点:
+    - 今回は user-facing UX 改善を優先するか、chat architecture hygiene を優先するか。
+
+- Defer option
+  - 目的: AWS deployment と broad chat backend rewrite は延期する。
+  - 期待効果:
+    - cycle を小さく安全に保つ。
+    - 不要な cost と operational complexity を避ける。
+  - 実装コスト: 低
+  - リスク:
+    - realtime chat と AWS deployment は production-grade には近づかない。
+
+3. decision-reviewer に推奨する focus
+
+- 最優先: Option A と Option C を採用する。
+  - Option A は home 価格帯ショートカットと `/search` の実挙動の不一致を直す。
+  - Option C は accessibility/semantic issue を小さな変更で直せる。
+- 次点: UI 変更を許容するなら Option B を検討する。ただし今回は deferred が妥当。
+- Option D、Option E、AWS/realtime backend rewrite は今回 defer を推奨する。
+
+4. decision-reviewer 向けの open questions / assumptions
+
+- parameterized `/search` pages は indexable にするか、`noindex, follow` にするか。
+- home の価格帯ショートカットは `/search` のままにするか、`/products` に寄せるか。
+- active chat implementation は `lib/chat/core/*` か。
+- ProductCard に seller trust metric を出すべきか。
+- 今回の cycle に visual CSS 変更を含めるべきか、semantic/functionality に限定すべきか。

--- a/docs/ai/output/product-review-packager/001-product-review-guide.md
+++ b/docs/ai/output/product-review-packager/001-product-review-guide.md
@@ -1,0 +1,171 @@
+1. レビュー概要
+
+- quality-reviewer の判定: **条件付きでレビュー可能**。
+- 実装された範囲:
+  - `/search` が `q`、`category`、`tag`、`priceMin`、`priceMax`、`sort` の検索パラメータに対応した。
+  - パラメータ付き検索結果ページは SEO 上 conservative に `noindex, follow` として扱う。
+  - root layout は nested `<main>` landmark を作らなくなり、skip link の遷移先 `#main` は維持された。
+- 主な caveat:
+  - 検索処理では無効な値を無視または正規化するが、canonical URL には `priceMin=-1` や `sort=invalid` のような raw な無効値が残る場合がある。
+
+2. 変更内容
+
+- 検索機能:
+  - `/search` は keyword、category、tag、価格帯、sort を既存の商品検索フローで処理する。
+  - 検索ページには結果件数、適用中条件、条件に応じた empty state を表示する。
+- SEO/AEO metadata:
+  - パラメータなしの `/search` は通常の検索ページとして扱う。
+  - 対応済みパラメータを持つ `/search?...` は `noindex, follow` として扱う。
+- アクセシビリティ/セマンティック構造:
+  - root layout の wrapper を `<main id="main">` から `<div id="main">` に変更した。
+  - ページ component 側が page-level `<main>` landmark を持つ方針を維持した。
+
+3. 確認すべき場所
+
+## 画面 / routes / URLs
+
+- `/search`
+  - 基本の検索ページ。
+- `/search?priceMin=3000`
+  - home の価格帯ショートカット相当の絞り込みを確認する。
+- `/search?priceMax=2000`
+  - 上限価格の絞り込みを確認する。
+- `/search?q=素材&category=photo&sort=price_asc`
+  - keyword、category、sort の組み合わせを確認する。
+- `/search?tag=商用利用&priceMin=1000&priceMax=5000&sort=price_desc`
+  - tag、価格帯、降順 sort の組み合わせを確認する。
+- `/`
+  - home の価格帯ショートカットが正しく遷移することを確認する。
+- 代表的な product/category/tag ページ
+  - root の `<main>` とページ側 `<main>` が nested になっていないことを確認する。
+
+## 関連ファイル
+
+- `app/(store)/search/page.tsx`
+- `app/layout.tsx`
+- `lib/seo/metadata.ts`
+- `data/products.ts`
+
+4. 検証手順
+
+1. ローカルでアプリを起動する。
+   - 推奨コマンド: `npm run dev`
+2. `/search?priceMin=3000` を開く。
+   - 表示される商品が 3,000円以上であることを確認する。
+   - `3,000円以上` のような適用中条件が表示されることを確認する。
+3. `/search?priceMax=2000` を開く。
+   - 表示される商品が 2,000円以下であることを確認する。
+4. `/search?q=素材&category=photo&sort=price_asc` を開く。
+   - 条件が組み合わさって適用されることを確認する。
+   - 価格が安い順に並ぶことを確認する。
+5. `/search?q=zzzzzzzz&priceMin=999999` を開く。
+   - 条件に一致する商品がない場合の empty state が表示されることを確認する。
+6. パラメータ付き検索ページの metadata を確認する。
+   - `noindex, follow` 相当の robots 設定があることを確認する。
+7. plain `/search` の metadata を確認する。
+   - filter 用の noindex 挙動が不要に付与されていないことを確認する。
+8. keyboard navigation で skip link を操作する。
+   - `#main` に移動できることを確認する。
+9. landmark を確認する。
+   - root layout が全 route を `<main>` で包んでいないことを確認する。
+   - 代表ページに page-level `<main>` が存在することを確認する。
+
+5. 以前の挙動と現在の挙動
+
+| 項目 | 以前 | 現在 |
+|---|---|---|
+| `/search?priceMin=3000` | 価格パラメータが検索ページで無視される場合があった。 | 最低価格で絞り込む。 |
+| `/search?priceMax=2000` | 価格パラメータが検索ページで無視される場合があった。 | 最高価格で絞り込む。 |
+| 複合条件 | 主に keyword 検索として動作していた。 | keyword、category、tag、価格帯、sort を組み合わせて処理する。 |
+| 検索結果説明 | 適用中条件が分かりにくかった。 | 件数と適用中条件を表示する。 |
+| empty state | 条件に応じた説明が弱かった。 | 検索条件の調整を促す。 |
+| SEO | パラメータ付き検索結果の扱いが明示的でなかった。 | `noindex, follow` として conservative に扱う。 |
+| landmark | root layout と page component の `<main>` が nested になる場合があった。 | root は `<div id="main">`、page 側が `<main>` を持つ。 |
+
+6. 既知の未解決事項
+
+- 低重大度の SEO metadata caveat:
+  - canonical URL は raw な対応済み query parameter から生成される。
+  - 検索処理では無効値を無視または正規化するが、canonical metadata には残る場合がある。
+  - 例:
+    - `/search?priceMin=-1`
+    - `/search?priceMax=abc`
+    - `/search?sort=invalid`
+- 影響:
+  - 検索結果の表示には影響しない。
+  - パラメータ付き検索ページは noindex のため、今回の product review をブロックしない。
+  - 次回以降、canonical も正規化済み条件から生成する改善を検討するとよい。
+
+7. human reviewer 向け decision points
+
+- 検索 UX:
+  - 適用中条件のラベルは分かりやすいか。
+  - default の `newest` も常に表示すべきか。
+  - 結果なし時の文言は十分に親切か。
+- SEO/AEO:
+  - パラメータ付き `/search` をすべて `noindex, follow` とする方針でよいか。
+  - `/search?q=...` も conservative に noindex とする方針でよいか。
+  - 次回 canonical の正規化 caveat を優先的に直すべきか。
+- navigation:
+  - home の価格帯ショートカットは `/search` のままでよいか。
+  - 将来的に `/products` を primary filtered listing にするか。
+- accessibility:
+  - skip link の動作は問題ないか。
+  - page-level `<main>` の範囲は自然か。
+
+8. human review checklist
+
+- [ ] `/search` がパラメータなしで表示される。
+- [ ] `/search?priceMin=3000` が価格で絞り込む。
+- [ ] `/search?priceMax=2000` が価格で絞り込む。
+- [ ] keyword、category、tag、価格帯、sort の複合条件が動作する。
+- [ ] 結果件数が表示商品数と一致する。
+- [ ] 適用中条件が URL パラメータと一致する。
+- [ ] 結果なし時の empty state が表示される。
+- [ ] パラメータ付き検索ページを indexable SEO landing page として扱っていない。
+- [ ] filtered/search-result pages の robots metadata が conservative である。
+- [ ] skip link が keyboard navigation で動作する。
+- [ ] root layout が nested `<main>` を作っていない。
+- [ ] ProductCard の意図しない redesign が含まれていない。
+- [ ] カテゴリ/タグ FAQ 追加が含まれていない。
+- [ ] chat architecture や AWS deployment の変更が含まれていない。
+- [ ] raw invalid canonical params の caveat を今回許容するか、follow-up にするか判断した。
+
+9. 次回 improvement-proposer cycle 向け feedback format
+
+```md
+## プロダクトレビュー結果
+
+判断:
+- Accept / Accept with follow-up / Request changes
+
+レビューした routes:
+- /search
+- /search?priceMin=3000
+- /search?priceMax=2000
+- /search?q=素材&category=photo&sort=price_asc
+- Other:
+
+良かった点:
+- 
+
+見つかった問題:
+- 
+
+SEO/AEO feedback:
+- 
+
+Accessibility feedback:
+- 
+
+次の優先事項:
+1. 
+2. 
+3. 
+
+次回 canonical caveat を扱うべきか:
+- Yes / No / Later
+
+追加メモ:
+- 
+```

--- a/docs/ai/output/quality-reviewer/001-quality-review.md
+++ b/docs/ai/output/quality-reviewer/001-quality-review.md
@@ -1,0 +1,91 @@
+1. レビュー範囲
+
+- 最新実装を decision-reviewer の **Accepted スコープのみ**に照らしてレビューした。
+  - **Option A**: `/search` が `q`、`category`、`tag`、`priceMin`、`priceMax`、`sort` を解析して適用し、既存の商品検索ロジックを再利用し、パラメータ付き検索ページに `noindex, follow` を付与していること。
+  - **Option C**: root layout の nested `<main>` landmark を解消し、skip link の遷移先を維持していること。
+- レビュー対象ファイル:
+  - `app/(store)/search/page.tsx`
+  - `app/layout.tsx`
+  - `lib/seo/metadata.ts`
+  - `docs/ai/output/...`
+- 実行した確認:
+  - `git status --short`
+  - `git log --oneline -5`
+  - `git show --stat --oneline HEAD`
+  - `git show --name-only --oneline HEAD`
+  - `sed -n '1,240p' 'app/(store)/search/page.tsx'`
+  - `sed -n '1,120p' app/layout.tsx`
+  - `sed -n '1,150p' lib/seo/metadata.ts`
+  - `rg "type ProductSearchFilters|function searchProducts|sort" data app components lib -n`
+  - `sed -n '1,260p' data/products.ts`
+  - `sed -n '1,130p' 'app/(store)/products/page.tsx'`
+  - `sed -n '1,120p' components/search/HomeSearchBar.tsx`
+  - `sed -n '1,80p' components/a11y/SkipLink.tsx`
+  - `find app -name 'page.tsx' -maxdepth 5 -print | sort | while read f; do if ! rg -q '<main' "$f"; then echo "NO_MAIN $f"; fi; done`
+  - `sed -n '1,180p' 'app/(store)/legal/LegalPageTemplate.tsx'`
+  - `npm run lint && npm run build`
+
+2. 重大度別の指摘
+
+## 重大
+
+- なし。
+
+## 高
+
+- なし。
+
+## 中
+
+- なし。
+
+## 低
+
+### 指摘 1 — 検索 canonical URL が、正規化後ではなく raw な無効フィルタ値を保持する場合がある
+
+- **根拠**
+  - `parsePrice` は無効値、非有限値、負数を検索条件から除外する。
+  - `parseSort` は未対応の sort 値を `newest` にフォールバックする。
+  - 一方で `buildSearchCanonical` は `q`、`category`、`tag`、`priceMin`、`priceMax`、`sort` の raw な値を canonical URL に反映する。
+  - 例:
+    - `/search?priceMin=-1` は検索条件としては `priceMin` なしとして扱われるが、canonical には `priceMin=-1` が残り得る。
+    - `/search?sort=unknown` は `newest` として並び替えられるが、canonical には `sort=unknown` が残り得る。
+
+- **影響**
+  - 検索結果そのものは正規化済み条件を使うため、商品表示の不具合ではない。
+  - パラメータ付き検索ページは `noindex, follow` のため、SEO リスクは限定的である。
+  - ただし canonical metadata の一貫性としては改善余地がある。
+
+- **推奨修正**
+  - canonical URL も正規化済み filters から生成する。
+  - 無効な `priceMin` / `priceMax` は canonical から除外する。
+  - 未対応の `sort` は canonical から除外するか、明示的に `newest` に正規化する。
+
+- **推奨検証**
+  - `/search?priceMin=-1`
+  - `/search?priceMax=abc`
+  - `/search?sort=invalid`
+  - `/search?priceMin=3000&sort=price_asc`
+  - 上記の metadata を確認し、無効値が canonical に残らないことを検証する。
+
+3. 指摘ごとの詳細
+
+- 低 の指摘 1 を参照。
+
+4. 良好だった確認項目
+
+- `/search` は accepted scope の検索パラメータを解析している。
+- `/search` は既存の `searchProducts(filters)` を再利用している。
+- 無効な価格値は検索条件として安全に無視される。
+- 検索結果 UI には件数、適用中条件、条件に応じた empty state が表示される。
+- パラメータ付き検索ページには `robots: { index: false, follow: true }` が適用される。
+- plain `/search` は通常の検索ページとして扱われる。
+- root layout は `<main id="main">` ではなく `<div id="main">` を使うため、root の `<main>` とページ側 `<main>` の nested landmark が解消された。
+- skip link は引き続き `#main` を指している。
+- Deferred だった ProductCard 改修、カテゴリ/タグ FAQ 追加、chat 整理、AWS 変更は含まれていない。
+- `npm run lint` と `npm run build` は成功した。
+
+5. 人によるレビューの準備状況: **条件付きでレビュー可能**
+
+- 実装は accepted scope を概ね満たしており、human product review に進められる。
+- Caveat は低重大度で、`/search` の canonical URL が検索条件の正規化後ではなく raw value を使う場合がある点である。

--- a/lib/seo/metadata.ts
+++ b/lib/seo/metadata.ts
@@ -93,11 +93,15 @@ export function buildTagMetadata(tag: string): Metadata {
   });
 }
 
-export function buildSearchMetadata(canonicalPath: string): Metadata {
+export function buildSearchMetadata(
+  canonicalPath: string,
+  options?: { robots?: Metadata['robots'] }
+): Metadata {
   return buildMetadataTemplate({
     title: '検索結果',
     description: 'サイト内検索結果ページです。',
     canonicalPath,
+    robots: options?.robots
   });
 }
 


### PR DESCRIPTION
### Motivation

- Ensure `/search` actually respects common query filters (`q`, `category`, `tag`, `priceMin`, `priceMax`, `sort`) so shortcuts and links return expected results. 
- Avoid indexing arbitrary filtered result pages by marking parameterized search results conservative for SEO. 
- Fix an accessibility issue caused by nested `<main>` landmarks by removing the root-level `<main>` wrapper.

### Description

- Parse and normalize search filters via new helpers (`parseFilters`, `parsePrice`, `parseSort`, `FILTER_KEYS`) and pass a `ProductSearchFilters` object to `searchProducts`. 
- Build canonical search URLs from supported filter keys and surface active filter labels (including localized sort labels) in the UI and empty states. 
- Add `robots` handling to search metadata and pass `robots: { index: false, follow: true }` when any search parameters are present by extending `buildSearchMetadata` signature. 
- Replace the root layout wrapper from `<main id="main">` to `<div id="main">` to avoid nested `<main>` landmarks and add several documentation files under `docs/ai/output/` recording decisions and implementation notes. 

### Testing

- Ran `npm run lint`, which completed successfully. 
- Ran `npm run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3960a06c5483288009a62d17984a82)