### PR TITLE
Refine home layout from human review feedback

### DIFF
--- a/app/(store)/search/page.tsx
+++ b/app/(store)/search/page.tsx
@@ -53,15 +53,32 @@ function hasSearchParameters(params: Record<string, string | string[] | undefine
   return FILTER_KEYS.some((key) => Boolean(readValue(params[key])?.trim()));
 }
 
-function buildSearchCanonical(params: Record<string, string | string[] | undefined>) {
+function buildSearchCanonical(filters: ProductSearchFilters) {
   const query = new URLSearchParams();
 
-  FILTER_KEYS.forEach((key) => {
-    const value = readValue(params[key])?.trim();
-    if (value) {
-      query.set(key, value);
-    }
-  });
+  if (filters.query) {
+    query.set('q', filters.query);
+  }
+
+  if (filters.category) {
+    query.set('category', filters.category);
+  }
+
+  if (filters.tag) {
+    query.set('tag', filters.tag);
+  }
+
+  if (typeof filters.priceMin === 'number') {
+    query.set('priceMin', String(filters.priceMin));
+  }
+
+  if (typeof filters.priceMax === 'number') {
+    query.set('priceMax', String(filters.priceMax));
+  }
+
+  if (filters.sort && filters.sort !== 'newest') {
+    query.set('sort', filters.sort);
+  }
 
   return query.toString() ? `/search?${query.toString()}` : '/search';
 }
@@ -99,7 +116,9 @@ function buildActiveFilterLabels(filters: ProductSearchFilters) {
 export async function generateMetadata({ searchParams }: Props): Promise<Metadata> {
   const params = await searchParams;
 
-  return buildSearchMetadata(buildSearchCanonical(params), {
+  const filters = parseFilters(params);
+
+  return buildSearchMetadata(buildSearchCanonical(filters), {
     robots: hasSearchParameters(params) ? { index: false, follow: true } : undefined
   });
 }
@@ -107,7 +126,7 @@ export async function generateMetadata({ searchParams }: Props): Promise<Metadat
 export default async function SearchPage({ searchParams }: Props) {
   const params = await searchParams;
   const filters = parseFilters(params);
-  const canonical = buildSearchCanonical(params);
+  const canonical = buildSearchCanonical(filters);
   const activeFilterLabels = buildActiveFilterLabels(filters);
 
   const items = searchProducts(filters);

--- a/app/globals.css
+++ b/app/globals.css
@@ -791,8 +791,21 @@ small,
   gap: var(--space-2);
 }
 
-.hero .home-search {
-  margin-top: var(--space-2);
+.home-search-section {
+  margin-top: var(--space-4);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: rgba(255, 255, 255, 0.72);
+  box-shadow: var(--shadow-sm);
+  padding: var(--space-5);
+}
+
+.home-search-section-copy {
+  max-width: 64ch;
+}
+
+.home-search-section .home-search {
+  margin-bottom: 0;
 }
 
 .home-search-row {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -151,12 +151,22 @@ export default async function HomePage({ searchParams }: Props) {
         <div className="hero-content">
           <p className="hero-label">DIGITAL CREATOR MARKET</p>
           <h1>毎日更新の特集で、欲しい素材にすぐ届く。</h1>
-          <HomeKeywordSearchBar initialQuery={q} />
           <p>
-            niko and ... の編集感とユニクロの分かりやすい導線を取り入れ、特集・カテゴリ・価格帯を1画面に集約。
-            壁紙・写真・イラスト・デジタル音源をテンポ良く比較し、購入前の不安はリアルタイムチャットで素早く解消できます。
+            niko and ... の編集感とユニクロの分かりやすい導線を取り入れ、特集・カテゴリ・価格帯を落ち着いて比較できる
+            デジタル素材マーケットです。購入前の不安はリアルタイムチャットで素早く解消できます。
           </p>
         </div>
+      </section>
+
+      <section className="home-search-section" aria-labelledby="home-search-title">
+        <div className="home-search-section-copy">
+          <p className="hero-label">SEARCH</p>
+          <h2 id="home-search-title">素材をキーワードで探す</h2>
+          <p className="section-description">
+            商品名・用途・タグから、必要な壁紙・写真・イラスト・音源へすぐ移動できます。
+          </p>
+        </div>
+        <HomeKeywordSearchBar initialQuery={q} />
       </section>
 
       <section className="feature-topics" aria-label="特集トピック">

--- a/components/layout/SiteHeader.tsx
+++ b/components/layout/SiteHeader.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 import { Container } from '@/components/ui/Container';
-import { getNavItems, isGuest } from '@/lib/auth/permissions';
+import { getNavItems } from '@/lib/auth/permissions';
 import type { UserRecord } from '@/lib/db/schema/user';
 
 type SiteHeaderProps = {
@@ -23,12 +23,6 @@ export function SiteHeader({ currentUser }: SiteHeaderProps) {
             </Link>
           ))}
         </nav>
-      </Container>
-      <Container>
-        <p className="hero-label" style={{ marginBottom: '0.5rem' }}>
-          ログイン中: {currentUser.displayName} / 権限:{' '}
-          {isGuest(currentUser) ? 'guest' : currentUser.roles.join(', ')}
-        </p>
       </Container>
     </header>
   );

--- a/components/search/HomeKeywordSearchBar.tsx
+++ b/components/search/HomeKeywordSearchBar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { type FormEvent, useTransition } from 'react';
-import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 
 type Props = {
   initialQuery?: string;
@@ -9,33 +9,28 @@ type Props = {
 
 export function HomeKeywordSearchBar({ initialQuery = '' }: Props) {
   const router = useRouter();
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
   const [isPending, startTransition] = useTransition();
 
   const onSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
     const formData = new FormData(event.currentTarget);
-    const params = new URLSearchParams(searchParams.toString());
     const q = String(formData.get('q') ?? '').trim();
+    const query = new URLSearchParams();
 
     if (q) {
-      params.set('q', q);
-    } else {
-      params.delete('q');
+      query.set('q', q);
     }
 
-    const query = params.toString();
-    const nextUrl = query ? `${pathname}?${query}` : pathname;
+    const nextUrl = query.toString() ? `/search?${query.toString()}` : '/search';
 
     startTransition(() => {
-      router.replace(nextUrl, { scroll: false });
+      router.push(nextUrl);
     });
   };
 
   return (
-    <form className="home-search" onSubmit={onSubmit} aria-label="ホーム商品キーワード検索フォーム">
+    <form className="home-search" action="/search" method="get" onSubmit={onSubmit} aria-label="ホーム商品キーワード検索フォーム">
       <div className="home-search-row">
         <label className="home-search-field">
           <span>キーワード</span>

--- a/docs/ai/output/decision-reviewer/002-human-review-layout-decisions.md
+++ b/docs/ai/output/decision-reviewer/002-human-review-layout-decisions.md
@@ -1,0 +1,141 @@
+1. Decision summary
+
+- **Accepted for implementation:** Option A, Option B, and Option C.
+- **Rejected for this cycle:** Broad visual redesign / full design-system rewrite, and sticky/header-level search-band redesign.
+- **Deferred:** Option D, realtime chat backend work, AWS deployment/infrastructure changes, and category/tag FAQ/HowTo content expansion.
+- The accepted scope should stay narrow: resolve the human review’s top UI/IA concern by separating the home title/value proposition from the search/action area, reduce public header debug noise, and fix the already-identified low-risk `/search` canonical inconsistency. The human review explicitly prioritizes separating title/description from search/actions and avoiding one large top card that mixes different roles. 【F:docs/ai/output/human-review/001-human-review.md†L17-L37】【F:docs/ai/output/human-review/001-human-review.md†L41-L73】
+
+2. Accepted items
+
+- **Item label:** Option A — Separate home hero/value proposition from search/action area.
+  - **Scope to implement:**
+    - Keep the home first view focused on brand/value proposition: brand label, single `h1`, and concise explanatory copy.
+    - Move `HomeKeywordSearchBar` out of the hero content into an independent search/action section immediately below the hero.
+    - Give the new search section an accessible label, preferably via `aria-labelledby` and a visible or screen-reader-friendly heading.
+    - Prefer a calm, low-density search section over another large “everything card”; do not introduce sticky behavior in this cycle.
+    - If touching the search form behavior, route submissions to the existing `/search?q=...` destination rather than only mutating the home page query, because the repository already has a dedicated `/search` page and the current home search only replaces the current pathname query. 【F:components/search/HomeKeywordSearchBar.tsx†L16-L35】【F:app/(store)/search/page.tsx†L99-L120】
+  - **Acceptance rationale:**
+    - This is the most direct response to the human review’s High feedback: separate title/description from search/operation elements, avoid concentrating dissimilar information in one top card, and clarify each section’s role. 【F:docs/ai/output/human-review/001-human-review.md†L30-L37】【F:docs/ai/output/human-review/001-human-review.md†L56-L73】
+    - The current home hero places slideshow, overlay, label, `h1`, search form, and description in one section, matching the structure the human review found visually overloaded. 【F:app/page.tsx†L146-L160】
+    - The change is visible and high-signal, but still reversible and localized to the home page and related styles/search component.
+
+- **Item label:** Option B — Reduce public `SiteHeader` information density and debug/role noise.
+  - **Scope to implement:**
+    - Remove the always-visible “ログイン中 / 権限” line from the public site header.
+    - Preserve the existing logo and role-aware navigation behavior.
+    - Do not add a new account system or new page; the existing navigation already includes login/mypage destinations depending on role. 【F:lib/auth/permissions.ts†L28-L64】
+    - If a development/debug role indicator is still needed, keep it out of the production-like public header and gate it behind an explicitly non-public/debug-only mechanism in a later cycle.
+  - **Acceptance rationale:**
+    - The current header always renders user display name and raw role labels directly under the main navigation, which increases visual noise and exposes implementation/demo state in a shopper-facing area. 【F:components/layout/SiteHeader.tsx†L13-L33】
+    - This is a low-cost support change for the human review’s request for a calmer, more polished top area.
+    - The implementation is small and reversible because it should not change authorization or navigation rules.
+
+- **Item label:** Option C — Normalize `/search` canonical URL generation.
+  - **Scope to implement:**
+    - Generate canonical URLs from normalized filter values rather than raw query parameters.
+    - Exclude invalid `priceMin` / `priceMax` values from canonical output.
+    - Exclude invalid `sort` values from canonical output, or normalize them consistently through the same sort parser.
+    - Treat `newest` as the default sort and omit it from canonical unless the repository already has a documented reason to keep default parameters.
+    - Keep unknown `category` / `tag` handling unchanged unless validation can be added without broad product-data policy changes.
+  - **Acceptance rationale:**
+    - The quality review already identified that `parsePrice` and `parseSort` normalize search behavior while `buildSearchCanonical` still reflects raw invalid values, creating canonical inconsistency. 【F:docs/ai/output/quality-reviewer/001-quality-review.md†L44-L63】
+    - The current implementation confirms canonical generation is raw-param based. 【F:app/(store)/search/page.tsx†L56-L67】
+    - This is a low-cost SEO/AEO cleanup that aligns metadata with actual search behavior without changing product display behavior.
+
+3. Rejected items
+
+- **Item label:** Broad visual redesign / full design-system rewrite.
+  - **Rejection rationale:**
+    - Rejected for this cycle because it is too speculative and too large relative to the evidence. The decision-reviewer rules prefer small, reversible, high-signal improvements and reject/defer speculative large rewrites. 【F:.codex/agents/decision-reviewer.toml†L24-L30】
+    - The human feedback is specific enough to address with targeted top-area IA changes first, not a full redesign.
+
+- **Item label:** Sticky/header-level search-band redesign for the home search.
+  - **Rejection rationale:**
+    - Rejected for this cycle because it expands layout and interaction risk, especially on mobile, before validating the simpler separation pattern.
+    - A non-sticky independent search section directly addresses the core feedback while keeping scope smaller and easier to reverse.
+
+4. Deferred items
+
+- **Item label:** Option D — Add category / file format / license / instant-download attributes to `ProductCard`.
+  - **Deferral rationale:**
+    - The ecommerce and AEO value is plausible, but adding more visible attributes to every product card may worsen the exact “not calm / not organized” impression raised by the human review.
+    - `ProductCard` is reused across listing surfaces, so even small density changes would affect multiple pages and should follow the top-area cleanup rather than ship in the same UI cycle. 【F:components/ProductCard.tsx†L31-L58】
+  - **Information needed to revisit:**
+    - Which attributes are mandatory for purchase confidence.
+    - Whether the product data model consistently contains file format, license, and instant-download status.
+    - Whether listings need separate compact/default card variants.
+    - Desktop and mobile density review after Option A/B are implemented.
+
+- **Item label:** Realtime chat backend integration.
+  - **Deferral rationale:**
+    - Realtime chat is a repository priority, but the current proposal is focused on human-reviewed UI/IA issues. Adding backend/chat architecture work would increase regression and infrastructure risk without directly addressing the reviewed layout problem.
+  - **Information needed to revisit:**
+    - Chat product requirements, realtime transport choice, persistence model, moderation needs, and AWS cost target.
+
+- **Item label:** AWS deployment / infrastructure / cost optimization.
+  - **Deferral rationale:**
+    - Minimum AWS cost is a repository priority, but no deployment requirement or cost problem is evidenced in this proposal. Infrastructure changes should not be mixed into a visible home/header UI cycle.
+  - **Information needed to revisit:**
+    - Target AWS services, expected traffic, budget ceiling, build/runtime constraints, and whether realtime chat must be included in the deployment design.
+
+- **Item label:** Category/tag FAQ/HowTo content expansion.
+  - **Deferral rationale:**
+    - AEO content expansion may be useful, but it risks thin or repetitive content unless guided by an approved content strategy.
+  - **Information needed to revisit:**
+    - Human-approved content tone, FAQ/HowTo eligibility rules, duplication policy, and target landing pages.
+
+5. Reasoning
+
+- **Repository priorities considered:**
+  - **Modern Next.js architecture:** The accepted work fits the existing Next.js App Router structure and does not require architectural rewrites. The project is already on Next.js 15.1.6 and React 19.0.0. 【F:package.json†L11-L16】
+  - **SEO / AEO quality:** Option A improves the semantic clarity of the home page’s primary message by separating value proposition from search UI. Option C directly fixes canonical metadata consistency for normalized search filters.
+  - **Ecommerce UX:** Option A clarifies the shopper journey from “understand the store value” to “search products.” Option B removes public header noise that makes the experience feel more like a demo than a polished storefront.
+  - **Realtime chat capability:** Deferred because the proposal does not provide enough chat-specific requirements and because adding backend work would distract from the human-reviewed layout issue.
+  - **Minimum AWS cost:** Accepted items are frontend/metadata changes and should not increase AWS runtime cost. Chat and infrastructure changes are deferred to avoid accidental cost expansion.
+  - **Learning value:** The accepted set teaches practical prioritization: address high-signal human review feedback, remove obvious UI noise, and resolve a bounded SEO metadata issue without over-designing.
+
+- **Cost / risk / reversibility notes:**
+  - Option A is medium cost because it is visibly user-facing and needs screenshot review, but it is localized and reversible.
+  - Option B is low cost and low risk if it only removes the debug-like role line while preserving navigation.
+  - Option C is low cost and should be covered with deterministic URL/metadata checks.
+  - Option D is deferred because the visual-density risk is higher than its current urgency.
+  - Realtime chat, AWS deployment, and generated AEO content are deferred because each requires dedicated requirements and risk review.
+
+6. Implementation handoff for implementer
+
+- **Only accepted items:**
+  - Implement Option A:
+    - Move home search out of `.hero-content`.
+    - Add a separate home search/action section immediately after the hero.
+    - Keep exactly one visible `h1`.
+    - Add accessible labeling to the search section.
+    - Prefer `/search?q=...` navigation for home search submissions if the search component is modified.
+    - Verify first-view spacing so product discovery sections are not pushed too far down.
+  - Implement Option B:
+    - Remove the visible “ログイン中 / 権限” line from `SiteHeader`.
+    - Keep logo and existing role-aware nav links unchanged.
+  - Implement Option C:
+    - Build `/search` canonical URLs from normalized filters.
+    - Drop invalid price and sort values from canonical.
+    - Omit default `sort=newest` from canonical unless a repository convention requires otherwise.
+    - Preserve current product search behavior.
+
+- **Explicit non-goals:**
+  - Do not perform a full visual redesign.
+  - Do not introduce a full design system rewrite.
+  - Do not add sticky header/search behavior.
+  - Do not add ProductCard metadata chips in this cycle.
+  - Do not implement realtime chat backend changes.
+  - Do not modify AWS deployment or infrastructure.
+  - Do not generate new FAQ/HowTo content.
+  - Do not change authorization/permission logic.
+
+- **Suggested validation commands or checks:**
+  - `npm run lint`
+  - `npm run build`
+  - Run the app locally with `npm run dev` and capture desktop/mobile screenshots of the home first view.
+  - Manually verify keyboard tab order through header, hero, search section, and first product section.
+  - Manually verify there is exactly one home page `h1`.
+  - Manually verify the home search has an accessible name and, if changed, submits to `/search?q=...`.
+  - Manually verify guest, buyer/seller, and admin navigation still shows the expected links.
+  - Manually verify `/search?priceMin=-1`, `/search?priceMax=abc`, `/search?sort=invalid`, and `/search?priceMin=3000&sort=price_asc` do not emit canonical URLs with invalid values.

--- a/docs/ai/output/implementer/002-implementation-result.md
+++ b/docs/ai/output/implementer/002-implementation-result.md
@@ -1,0 +1,37 @@
+1. Accepted scope implemented
+
+- Implemented Option A by separating the home hero/value proposition from the keyword search/action area. The hero now keeps the brand label, a single visible `h1`, and concise explanatory copy, while the search form is placed in an independent section immediately below the hero with `aria-labelledby`.
+- Implemented Option B by removing the always-visible public header login/role line while preserving the existing logo and role-aware navigation rendering.
+- Implemented Option C by generating `/search` canonical URLs from parsed/normalized filters, excluding invalid price values, excluding invalid sort values, and omitting the default `sort=newest` parameter.
+
+2. Files changed and why
+
+- `app/page.tsx`: Moved `HomeKeywordSearchBar` out of `.hero-content`, added the separate labeled home search section, and tightened hero copy to keep the first view focused on value proposition.
+- `app/globals.css`: Added low-density styling for the new home search section and removed the hero-specific search margin rule that no longer applies.
+- `components/search/HomeKeywordSearchBar.tsx`: Updated submission behavior to navigate to the dedicated `/search?q=...` route instead of mutating the current page query.
+- `components/layout/SiteHeader.tsx`: Removed the public debug-like login/role line and unused `isGuest` import while keeping role-aware nav items intact.
+- `app/(store)/search/page.tsx`: Changed canonical URL generation to use normalized `ProductSearchFilters` instead of raw query parameters.
+
+3. Behavior changes
+
+- The home first view presents the store message first, then a separate “素材をキーワードで探す” search section immediately below it.
+- Home keyword searches now route to `/search` with the `q` parameter when present, or `/search` for an empty query.
+- The public header no longer exposes the current demo user name or raw role labels.
+- Search canonical URLs now drop invalid `priceMin`, invalid `priceMax`, invalid `sort`, and default `sort=newest`; valid non-default filters remain in canonical output.
+
+4. Validation commands run or recommended
+
+- Ran `npm run lint` successfully.
+- Ran `npm run build` successfully. Next.js emitted its existing edge-runtime static-generation warning during build, but the build completed successfully.
+- Ran `npm start` and verified canonical output with a Python `urllib.request` check for `/search?priceMin=-1`, `/search?priceMax=abc`, `/search?sort=invalid`, `/search?priceMin=3000&sort=price_asc`, and `/search?sort=newest`.
+- Attempted to capture a screenshot with `npx --yes playwright screenshot --viewport-size=1440,1100 http://127.0.0.1:3000 /tmp/hobby-screenshots/home.png`, but the environment blocked fetching Playwright from npm with `403 Forbidden`; no screenshot was produced.
+
+5. Known follow-ups that were intentionally not implemented
+
+- Did not perform a broad visual redesign or design-system rewrite.
+- Did not add sticky header/search behavior.
+- Did not add ProductCard metadata chips or listing density changes.
+- Did not implement realtime chat backend changes.
+- Did not modify AWS deployment or infrastructure.
+- Did not generate new FAQ/HowTo content.
+- Did not change authorization or permission logic.

--- a/docs/ai/output/improvement-proposer/002-human-review-layout-proposals.md
+++ b/docs/ai/output/improvement-proposer/002-human-review-layout-proposals.md
@@ -1,0 +1,131 @@
+1. Context observed
+
+- この subagent は `improvement-proposer` として、実装・編集・採用判断は行わず、改善 option の提示のみを行う前提で確認した。参照した主な terminal command は `git status --short`, `git log --oneline -5`, `rg --files ...`, `cat .codex/agents/improvement-proposer.toml`, `cat docs/ai/output/human-review/001-human-review.md`, `sed -n ...`, `nl -ba ...`。
+- repository は Next.js App Router 構成で、`next@15.1.6`, `react@19.0.0`, TypeScript を使っている。`npm run lint`, `npm run build`, `next dev`, `next start` scripts も定義されている。 【F:package.json†L5-L16】
+- human review は、現在の UI が「落ち着きがあり、洗練されたサイト」から離れており、構成や統一感が弱いと指摘している。特に「タイトル・説明・検索バー・ナビゲーション要素」が上部の一つのカード内に詰め込まれているように見え、タイトル領域と検索/操作領域を分離したいという方向性が示されている。 【F:docs/ai/output/human-review/001-human-review.md†L5-L12】【F:docs/ai/output/human-review/001-human-review.md†L17-L37】【F:docs/ai/output/human-review/001-human-review.md†L41-L62】
+- human review の High 改善案は、ヘッダー周辺レイアウト再設計、タイトル領域と検索領域の分離、上部の大きなカードへの集約回避、情報の役割ごとのセクション分離である。 【F:docs/ai/output/human-review/001-human-review.md†L66-L73】
+- 現在の home page では、hero section 内に slideshow / overlay / label / h1 / `HomeKeywordSearchBar` / 説明文がまとまっている。これは human review の「タイトル・説明・検索バーを同じ上部カードにまとめない」という要望とまだ近い構造に見える。 【F:app/page.tsx†L146-L160】
+- home page には、feature topics、注目商品、新着商品、ランキング風説明、カテゴリ、価格帯、タグ、chat CTA など、複数の発見導線が既にある。 【F:app/page.tsx†L162-L179】【F:app/page.tsx†L194-L223】【F:app/page.tsx†L225-L275】
+- `SiteHeader` は site logo と nav を持ち、さらに header 内でログイン中ユーザー/権限を `hero-label` style で常時表示している。これは開発/デモ情報としては有用だが、一般 user 向けの「落ち着いた洗練 UI」にはノイズになり得る。 【F:components/layout/SiteHeader.tsx†L13-L33】
+- `HomeKeywordSearchBar` は現在の pathname に対して `q` を付け替える `router.replace` 型で、home page 内の検索状態更新として動く設計である。検索実行後に `/search?q=...` へ移動する導線ではない。 【F:components/search/HomeKeywordSearchBar.tsx†L10-L35】【F:components/search/HomeKeywordSearchBar.tsx†L37-L59】
+- `/search` は前 cycle で `q`, `category`, `tag`, `priceMin`, `priceMax`, `sort` を parse し、商品検索へ渡す構造になっている。 【F:app/(store)/search/page.tsx†L17-L49】【F:app/(store)/search/page.tsx†L107-L135】
+- `/search` の metadata/canonical は、raw query parameter から canonical path を作っており、quality review は invalid `priceMin`, `priceMax`, `sort` が canonical に残る低重大度 issue を指摘している。 【F:app/(store)/search/page.tsx†L56-L67】【F:app/(store)/search/page.tsx†L99-L104】【F:docs/ai/output/quality-reviewer/001-quality-review.md†L42-L69】
+- `ProductCard` は Product microdata、placeholder image、favorite、name、price、detail CTA を表示するが、category / tag / license / file format / 即時 DL などの比較情報は visible UI としてはまだ少ない。 【F:components/ProductCard.tsx†L31-L58】
+- CSS 上、`main` は site-wide max-width/padding を持ち、`.hero` は border, radius, shadow, background, overlay を持つ大きな card-like section として定義されている。 【F:app/globals.css†L129-L136】【F:app/globals.css†L722-L731】
+- 事実と仮定の分離:
+  - 事実: human review は「落ち着いた・洗練された UI」「ヘッダー/上部エリアの情報設計」「タイトルと検索の分離」を強く求めている。 【F:docs/ai/output/human-review/001-human-review.md†L7-L11】【F:docs/ai/output/human-review/001-human-review.md†L68-L79】
+  - 事実: 前 cycle の quality review で `/search` canonical 正規化の小さな SEO issue が残っている。 【F:docs/ai/output/quality-reviewer/001-quality-review.md†L44-L69】
+  - 仮定: 次 cycle は broad rewrite ではなく、human review で明示された top UI/IA の違和感を小さく解消するのが最も安全。
+  - 仮定: production 向けには header の権限表示は必要最小限に抑え、account/admin など適切な場所に移す方が ecommerce UX と信頼感に合う。
+
+2. Improvement options
+
+- Option A
+  - Purpose: home hero を「ブランド/価値提案」領域と「検索/操作」領域に分離し、human review の High 指摘に最小 scope で対応する。
+  - Expected impact:
+    - UX: 上部の視線導線が整理され、h1 と説明文を読ませる領域、検索する領域が明確になる。
+    - Ecommerce UX: user が「まず価値を理解する」「次に検索する」という流れを取りやすくなる。
+    - SEO/AEO: h1 と説明文が検索 form に埋もれにくくなり、page の primary topic が machine-readable に明確になる。
+    - A11y: search form を独立 section にし、`aria-labelledby` を付けることで landmark/section navigation が分かりやすくなる。
+  - Implementation cost: Medium
+  - Risks:
+    - visible design change のため、スクリーンショット確認が必要。
+    - hero visual を弱めすぎると現状の「特集感」が減る可能性がある。
+    - home page の上部余白が増えすぎると first view の商品導線が下がる。
+  - Adoption decision points:
+    - 検索 form は hero 直下の独立 card にするか、header 下の sticky/search band にするか。
+    - hero の slideshow/background を維持するか、より静的で落ち着いた editorial header にするか。
+    - h1 下の長い説明文は短縮するか、別 section に移すか。
+    - validation: desktop/mobile screenshot、keyboard tab order、`h1` が 1 つであること、search form の accessible name、Lighthouse/axe 相当の landmark 確認。
+
+- Option B
+  - Purpose: `SiteHeader` の情報密度を下げ、ログイン/権限表示を account/admin 向けの控えめな場所へ移す、または production-like 表示では非表示にする。
+  - Expected impact:
+    - UX: header が logo/navigation に集中し、落ち着いた ecommerce site に近づく。
+    - Ecommerce trust: 「権限: guest/admin」などの内部状態表示が一般 shopper の視界に入りにくくなり、デモ感を抑えられる。
+    - SEO/AEO: 直接の ranking impact は小さいが、header の boilerplate/noise が減り、main content への集中度が上がる。
+    - Security perception: 実権限名を常時見せる設計から離れられる。
+  - Implementation cost: Low
+  - Risks:
+    - 開発/レビュー時に現在の user role が見えにくくなる。
+    - guest/admin/seller navigation の切り替え確認が少し不便になる。
+    - 既存 E2E/manual review が header 内の表示に依存している場合は調整が必要。
+  - Adoption decision points:
+    - ログイン状態表示は header 右端に「マイページ」だけ残すか、完全に account page へ移すか。
+    - demo/debug 表示は environment flag で開発時だけ表示するか。
+    - admin/seller role の明示は `/admin` / `/seller` 側だけでよいか。
+    - validation: guest/login/admin の header screenshot、nav items の表示確認、mobile wrapping 確認。
+
+- Option C
+  - Purpose: quality review が残した `/search` canonical 正規化 issue を修正候補として扱い、invalid/raw query が canonical に残らないようにする。
+  - Expected impact:
+    - SEO: invalid parameter URL の canonical inconsistency を減らし、`noindex, follow` と canonical の整合性が上がる。
+    - AEO: search result metadata が実際の正規化済み条件に近づき、AI crawler / search engine にとって URL intent が明確になる。
+    - Maintainability: `parseFilters` と canonical generation の責務を揃えられる。
+  - Implementation cost: Low
+  - Risks:
+    - `sort=newest` を canonical に含める/含めない判断で URL policy が揺れる可能性がある。
+    - `category` / `tag` の unknown value をどう canonical 化するか決める必要がある。
+    - `/search` は `noindex` なので business impact は小さく、human review の UI 改善より優先度を上げすぎると product feedback 対応が遅れる。
+  - Adoption decision points:
+    - canonical は normalized filters から生成するか、raw params を sanitize するだけにするか。
+    - `sort=newest` は default として canonical から省くか、明示的に残すか。
+    - unknown `category` / `tag` は現状通り残すか、known values のみに制限するか。
+    - validation: `/search?priceMin=-1`, `/search?priceMax=abc`, `/search?sort=invalid`, `/search?priceMin=3000&sort=price_asc` の metadata/canonical 確認。 【F:docs/ai/output/quality-reviewer/001-quality-review.md†L64-L69】
+
+- Option D
+  - Purpose: `ProductCard` に category / file format / license / 即時 DL など、購入判断に必要な最小限の visible attribute を追加する。
+  - Expected impact:
+    - Ecommerce UX: listing 上で比較できる情報が増え、商品詳細へ行く前の判断がしやすくなる。
+    - SEO/AEO: Product entity の visible content と structured/microdata の整合が高まり、AI engine が商品特徴を把握しやすくなる。
+    - Conversion: ライセンスや形式への不安をカード段階で減らせる。
+  - Implementation cost: Medium
+  - Risks:
+    - card density が上がり、human review の「落ち着きがない」印象を悪化させる可能性がある。
+    - home / search / category / ranking / deals など複数 surface に同じ card が出るため、見た目の影響範囲が広い。
+    - 詳細表示項目を増やしすぎると CTA が埋もれる。
+  - Adoption decision points:
+    - 今回は「category + file format + license」程度に限定するか。
+    - tag は表示しない/1個だけ/複数 chip のどれにするか。
+    - home の featured/new arrivals と listing で同じ密度にするか、compact variant を設けるか。
+    - validation: grid density の desktop/mobile screenshot、Product microdata と visible text の整合確認。
+
+- Defer option
+  - Purpose: realtime chat backend 統合、AWS deployment/infrastructure、category/tag FAQ/HowTo content 拡張は今回 defer する。
+  - Expected impact:
+    - cycle を human review の top UI/IA feedback と search SEO caveat に集中できる。
+    - AWS cost や chat regression risk を増やさず、安全な visible improvement に限定できる。
+    - AEO content 拡張は human-approved content strategy 後に行うことで thin/repetitive content risk を抑えられる。
+  - Implementation cost: Low
+  - Risks:
+    - realtime chat capability と AWS production readiness は進まない。
+    - category/tag landing page の AEO 強化は次 cycle 以降になる。
+  - Adoption decision points:
+    - 今回の目的を「human review の UI 違和感解消」に絞るか。
+    - chat/AWS は次の dedicated architecture review に回すか。
+    - FAQ/HowTo は content guideline 作成後に回すか。
+
+3. Recommended decision-reviewer focus
+
+- 最も判断すべき焦点は、Option A と Option B を同じ cycle で小さく採用するかどうか。
+  - human review の High 指摘に最も直接対応するのは Option A。
+  - header のノイズを減らして「落ち着いた、洗練された」印象に寄せる補助策として Option B は低 cost。
+- Option C は quality-reviewer の明確な low issue なので、UI 改修と一緒に入れてもよい。ただし human review 対応が主目的なら、Option C は「同時に直す小修正」または「次 cycle の first issue」として扱うのが妥当。
+- Option D は ecommerce/AEO value はあるが、card density が増えるため、human review の「見せ方が整理されていない」という指摘と衝突し得る。今回採用するなら表示項目をかなり絞るべき。
+- Defer 推奨:
+  - realtime chat backend の整理
+  - AWS deploy/cost optimization
+  - category/tag FAQ/HowTo content generation
+  - broad visual redesign / full design system rewrite
+- decision-reviewer は、次 cycle の acceptance criteria を「home first view が title/value proposition と search action に分離されている」「header に debug/role 感が出すぎない」「search canonical caveat を直すか延期するか」に絞ると安全。
+
+4. Open questions or assumptions for decision-reviewer
+
+- home hero の検索 form は、hero から完全に出して独立 section にするべきか、それとも hero 内で visual separation だけ強めれば十分か。
+- hero slideshow は「洗練された編集感」に寄与しているか、それとも card-like/noisy な印象の原因になっているか。
+- header の「ログイン中: displayName / 権限: ...」は production-like UI でも必要か、開発/debug 専用表示にするべきか。 【F:components/layout/SiteHeader.tsx†L27-L32】
+- home search は現在 home URL の query を更新するが、user expectation と SEO/AEO を考えると `/search?q=...` に遷移する方が自然か。 【F:components/search/HomeKeywordSearchBar.tsx†L16-L35】
+- `/search` canonical normalization は今回の UI cycle に含めるか、SEO maintenance cycle に分けるか。
+- ProductCard の情報追加は human review の「落ち着き」改善後に再評価するか、今回ごく小さく入れるか。
+- スクリーンショット基準として、どの viewport を human review の主対象にするか。例: desktop 1440px、tablet、mobile 390px。
+- AEO content を増やす場合、human-approved な FAQ/HowTo tone と重複回避ルールを先に決める必要がある、という前提でよいか。

--- a/docs/ai/output/product-review-packager/002-human-review-layout-review-guide.md
+++ b/docs/ai/output/product-review-packager/002-human-review-layout-review-guide.md
@@ -1,0 +1,182 @@
+1. **Review summary**
+
+- This package covers the implemented human-review layout cycle for the storefront home/search/header experience.
+- The accepted work focused on:
+  - Separating the home hero/value proposition from the keyword search action.
+  - Reducing public header noise by removing the visible login/role debug-style line.
+  - Normalizing `/search` canonical URLs from parsed filter values.
+  - Addressing the quality-review medium finding by adding native form fallback attributes: `action="/search"` and `method="get"` on the home search form. 【F:components/search/HomeKeywordSearchBar.tsx†L32-L34】
+- The change is ready for human product review, with one main caveat: desktop/mobile visual screenshots were not captured in the implementation environment, so spacing, density, and first-view polish still need hands-on review.
+
+2. **What changed**
+
+- The home hero now contains the brand label, one visible `h1`, and concise value-proposition copy only. 【F:app/page.tsx†L148-L158】
+- The keyword search form was moved into a separate section immediately below the hero, labeled with `aria-labelledby="home-search-title"`. 【F:app/page.tsx†L161-L170】
+- The search section has its own low-density card styling, instead of being embedded inside the hero content. 【F:app/globals.css†L794-L809】
+- Home keyword searches now target the dedicated `/search` route:
+  - Native fallback: `action="/search"` and `method="get"`. 【F:components/search/HomeKeywordSearchBar.tsx†L32-L34】
+  - Hydrated client behavior: builds `/search?q=...` or `/search` and uses `router.push`. 【F:components/search/HomeKeywordSearchBar.tsx†L14-L29】
+- The public header no longer shows the previous always-visible “ログイン中 / 権限” style user/role line; it now shows the logo and role-aware navigation only. 【F:components/layout/SiteHeader.tsx†L13-L27】
+- `/search` canonical URL generation now uses normalized filters:
+  - Keeps valid `q`, `category`, `tag`, `priceMin`, `priceMax`.
+  - Omits invalid price/sort values through parsing.
+  - Omits default `sort=newest`.
+  - Preserves valid non-default sort values. 【F:app/(store)/search/page.tsx†L56-L83】
+
+3. **Where to look**
+
+- **Screens / routes / URLs**
+  - `/`
+    - Main review target.
+    - Check the top hero, the separated search section, first-view hierarchy, and whether the page feels calmer and more polished.
+  - `/search?q=壁紙`
+    - Verify home search lands on the search results page with the query preserved.
+  - `/search`
+    - Verify empty search submission still lands on the search page.
+  - `/search?priceMin=-1`
+    - Confirm invalid `priceMin` does not appear in canonical output.
+  - `/search?priceMax=abc`
+    - Confirm invalid `priceMax` does not appear in canonical output.
+  - `/search?sort=invalid`
+    - Confirm invalid `sort` does not appear in canonical output.
+  - `/search?sort=newest`
+    - Confirm default sort is omitted from canonical output.
+  - `/search?priceMin=3000&sort=price_asc`
+    - Confirm valid non-default filters remain in canonical output.
+
+- **Components or flows**
+  - Home page hero and separated search section: `app/page.tsx`. 【F:app/page.tsx†L148-L170】
+  - Home search form behavior and native fallback: `components/search/HomeKeywordSearchBar.tsx`. 【F:components/search/HomeKeywordSearchBar.tsx†L14-L54】
+  - Header navigation display: `components/layout/SiteHeader.tsx`. 【F:components/layout/SiteHeader.tsx†L13-L27】
+  - Search canonical normalization: `app/(store)/search/page.tsx`. 【F:app/(store)/search/page.tsx†L56-L83】
+  - Search-section styling: `app/globals.css`. 【F:app/globals.css†L794-L826】
+
+4. **Verification steps**
+
+- ✅ `npm run lint`
+  - Implementer and quality reviewer reported this passed.
+- ✅ `npm run build`
+  - Implementer and quality reviewer reported this passed.
+  - Build emitted an existing edge-runtime static-generation warning, but completed successfully.
+- ✅ `npm start`
+  - Quality reviewer reported this was used for HTTP probing.
+- ✅ Python `urllib.request` HTTP probe against `/`, `/search?priceMin=-1`, `/search?priceMax=abc`, `/search?sort=invalid`, `/search?priceMin=3000&sort=price_asc`, and `/search?sort=newest`
+  - Quality reviewer reported this confirmed one home `h1`, no header login/role noise, search-section marker presence, and expected canonical normalization.
+- ⚠️ `npx --yes playwright screenshot --viewport-size=1440,1100 http://127.0.0.1:3000 /tmp/hobby-screenshots/home.png`
+  - Implementer reported this could not complete because the environment blocked fetching Playwright with `403 Forbidden`; no screenshot was produced.
+- Manual product review checks:
+  - Open `/` on desktop and mobile widths.
+  - Confirm the hero reads as a calm value-proposition area, not a mixed “everything card.”
+  - Confirm the search section feels visually separate but not overly heavy.
+  - Submit a keyword from `/` and confirm the destination is `/search?q=<keyword>`.
+  - Disable JavaScript, or test before hydration if possible, and confirm native form submission still lands on `/search?q=<keyword>`.
+  - Confirm keyboard tab order flows naturally through header, hero/search, and product discovery sections.
+  - Confirm there is exactly one visible home-page `h1`.
+  - Inspect page source or metadata for the canonical URL behavior on the `/search` test URLs above.
+
+5. **Previous behavior vs latest behavior**
+
+| Area | Previous behavior | Latest behavior |
+|---|---|---|
+| Home top area | Hero bundled slideshow, label, `h1`, description, and search together, reinforcing the “top card is overloaded” concern. | Hero now focuses on brand/value proposition only; search moved to a separate section below. 【F:app/page.tsx†L148-L170】 |
+| Home search destination | Search behavior previously mutated the current page query instead of clearly sending users to `/search`. | Search now targets `/search`, both through client navigation and native form fallback. 【F:components/search/HomeKeywordSearchBar.tsx†L14-L34】 |
+| No-JS / pre-hydration search | Quality review found the form lacked native fallback, so browser default behavior could remain on `/?q=...`. | Parent follow-up added `action="/search"` and `method="get"`, so native submission now reaches `/search?q=...`. 【F:components/search/HomeKeywordSearchBar.tsx†L32-L34】 |
+| Public header | Header showed visible login/display-name and role/debug-like information. | Header shows logo and role-aware navigation only. 【F:components/layout/SiteHeader.tsx†L13-L27】 |
+| Search canonical URL | Canonical generation reflected raw query values, so invalid price/sort parameters could remain. | Canonical is built from normalized filters and omits invalid/default values. 【F:app/(store)/search/page.tsx†L56-L83】 |
+
+6. **Known unresolved issues**
+
+- Desktop and mobile screenshots are still missing because the implementation environment could not fetch Playwright.
+- Human visual review is still required for:
+  - First-view hierarchy.
+  - Hero/search spacing.
+  - Whether the new search section feels calm and polished.
+  - Whether product discovery content is pushed too far down.
+- Product card metadata chips were intentionally not added in this cycle.
+- Sticky search/header search redesign was intentionally not added.
+- Realtime chat backend changes were intentionally not implemented.
+- AWS deployment/infrastructure changes were intentionally not implemented.
+- FAQ/HowTo AEO content expansion was intentionally deferred.
+- No broad visual redesign or full design-system rewrite was included.
+
+7. **Decision points for the human reviewer**
+
+- Does the new top-page structure solve the original concern that title, description, search, and operations felt crowded into one upper card?
+- Is the separate search section visually calm enough, or does it still feel like another large card competing with the hero?
+- Is the hero copy concise and polished enough for the desired brand impression?
+- Should the hero slideshow/background remain as-is, or should a future cycle simplify it further for a more editorial, premium feel?
+- Is the removal of visible login/role information from the public header acceptable for review/demo workflows?
+- Is `/search` the right destination for all home keyword searches?
+- Should default/invalid canonical normalization policy be extended later to stricter `category` / `tag` validation?
+- Should the next improvement cycle focus on visual polish, product-card purchase confidence, AEO content strategy, realtime chat, or AWS deployment readiness?
+
+8. **Human review checklist**
+
+- [ ] On desktop, the home first view feels calmer and more polished than before.
+- [ ] On mobile, the hero and search section do not feel cramped or overly tall.
+- [ ] The `h1` and value proposition are easy to understand before interacting with search.
+- [ ] The search section is clearly separate from the hero.
+- [ ] The search section does not look like another overloaded “everything card.”
+- [ ] Search from `/` with a keyword lands on `/search?q=<keyword>`.
+- [ ] Empty search from `/` lands on `/search`.
+- [ ] Native/no-JS form behavior also lands on `/search`.
+- [ ] Header no longer shows public debug-like login/role text.
+- [ ] Header navigation still shows expected links for guest, buyer/seller, and admin states.
+- [ ] `/search` canonical URLs drop invalid price/sort parameters.
+- [ ] Default `sort=newest` is omitted from canonical output.
+- [ ] Valid non-default filters remain in canonical output.
+- [ ] No unexpected changes are visible on product cards, chat, AWS/deployment behavior, or FAQ/HowTo content.
+
+9. **Suggested feedback format for the next improvement-proposer cycle**
+
+```md
+## Overall decision
+
+- Approve / Approve with requested follow-up / Request changes
+
+## Top-page layout feedback
+
+- Hero/value proposition:
+  - What works:
+  - What feels off:
+  - Desired adjustment:
+
+- Search section:
+  - What works:
+  - What feels off:
+  - Desired adjustment:
+
+- Header:
+  - Is the reduced header acceptable?
+  - Any missing account/demo information?
+
+## Search behavior / SEO-AEO feedback
+
+- Is `/search?q=...` the expected destination from home search?
+- Any concerns with canonical normalization?
+- Should category/tag canonical handling be stricter in a future cycle?
+
+## Visual review notes
+
+- Desktop:
+- Mobile:
+- Spacing/density:
+- Brand impression:
+
+## Next-cycle priority
+
+Choose one primary focus:
+
+1. Further home/header visual polish
+2. Product-card purchase-confidence information
+3. Search/category/tag AEO content strategy
+4. Realtime chat backend/product flow
+5. AWS deployment and minimum-cost architecture
+6. Other:
+
+## Specific examples or screenshots
+
+- Route / screenshot:
+- Issue:
+- Expected direction:
+```

--- a/docs/ai/output/quality-reviewer/002-human-review-layout-quality-review.md
+++ b/docs/ai/output/quality-reviewer/002-human-review-layout-quality-review.md
@@ -1,0 +1,70 @@
+1. **Review scope**
+
+- Reviewed the latest implementation described in `docs/ai/output/implementer/002-implementation-result.md` against the accepted decisions in `docs/ai/output/decision-reviewer/002-human-review-layout-decisions.md`.
+- Focused on changed implementation files: `app/page.tsx`, `app/globals.css`, `components/search/HomeKeywordSearchBar.tsx`, `components/layout/SiteHeader.tsx`, and `app/(store)/search/page.tsx`. The implementer reported these same files as changed for Options A, B, and C. 【F:docs/ai/output/implementer/002-implementation-result.md†L7-L13】
+- Decision scope reviewed:
+  - Option A: separate home hero/value proposition from search/action area, keep one visible `h1`, add accessible search-section labeling, and route touched search behavior to `/search?q=...`. 【F:docs/ai/output/decision-reviewer/002-human-review-layout-decisions.md†L10-L20】
+  - Option B: remove the public “ログイン中 / 権限” header line while preserving role-aware navigation. 【F:docs/ai/output/decision-reviewer/002-human-review-layout-decisions.md†L22-L31】
+  - Option C: normalize `/search` canonical URLs from parsed filters, drop invalid price/sort values, and omit default `sort=newest`. 【F:docs/ai/output/decision-reviewer/002-human-review-layout-decisions.md†L33-L43】
+  - Explicit non-goals checked for scope drift: no design-system rewrite, sticky search, ProductCard metadata chips, realtime chat backend, AWS/infrastructure, FAQ/HowTo content generation, or authorization logic changes. 【F:docs/ai/output/decision-reviewer/002-human-review-layout-decisions.md†L123-L131】
+
+2. **Findings by severity**
+
+## Critical
+
+- No findings.
+
+## High
+
+- No findings.
+
+## Medium
+
+### Finding: Home search only routes to `/search` after client JavaScript handles submit
+
+- **Evidence**
+  - The accepted decision says touched home search behavior should route submissions to the existing `/search?q=...` destination rather than only changing the home page query. 【F:docs/ai/output/decision-reviewer/002-human-review-layout-decisions.md†L16-L16】
+  - The implementation does route to `/search` in the client `onSubmit` handler via `router.push(nextUrl)`. 【F:components/search/HomeKeywordSearchBar.tsx†L14-L29】
+  - However, the rendered `<form>` has no `action="/search"` or `method="get"` fallback; it only has `className`, `onSubmit`, and `aria-label`. 【F:components/search/HomeKeywordSearchBar.tsx†L32-L54】
+- **Impact**
+  - For users submitting before hydration, with JavaScript disabled, or if the client bundle fails, the browser will use the HTML form default action/current URL. On the home page, that means `/?q=...` rather than `/search?q=...`, leaving users on the home page instead of the dedicated search results page.
+  - This is a progressive-enhancement gap in an ecommerce discovery path. It does not block normal hydrated usage, but it weakens the decision’s intended behavior and modern Next.js robustness.
+- **Recommended fix**
+  - Add native form attributes so the server-rendered HTML also submits to search: `action="/search"` and `method="get"`.
+  - Keep the client `onSubmit` only if the app still wants client-side navigation, but ensure the no-JS/native path reaches the same `/search?q=...` destination.
+- **Suggested validation**
+  - Validate with JavaScript disabled or before hydration that entering a keyword on `/` lands on `/search?q=<keyword>`.
+  - Re-run canonical/search checks after adding the fallback.
+
+## Low
+
+### Finding: Visual first-view validation remains incomplete because no screenshot was captured
+
+- **Evidence**
+  - The decision handoff requested local desktop/mobile screenshot review of the home first view and manual checks for first-view spacing, tab order, single `h1`, and search accessible naming. 【F:docs/ai/output/decision-reviewer/002-human-review-layout-decisions.md†L133-L141】
+  - The implementer reports the screenshot attempt failed because the environment blocked fetching Playwright, so no screenshot was produced. 【F:docs/ai/output/implementer/002-implementation-result.md†L24-L27】
+- **Impact**
+  - The code structure satisfies the intended separation, but the human reviewer still lacks visual evidence for the most user-facing part of the change: whether the hero/search separation is calm, low-density, and does not push discovery content too far down.
+- **Recommended fix**
+  - Capture desktop and mobile screenshots using an already-available browser tool or in a local environment where Playwright/browser binaries are installed.
+- **Suggested validation**
+  - Review `/` at desktop and mobile widths for first-view hierarchy, search section density, and spacing before final product review.
+
+3. **Positive checks passed**
+
+- The home page now keeps the hero focused on label, single visible `h1`, and explanatory copy, with the search moved into a separate `aria-labelledby="home-search-title"` section immediately after the hero. 【F:app/page.tsx†L146-L170】
+- The new search section has low-density styling and responsive button behavior without introducing sticky/header-level search behavior. 【F:app/globals.css†L794-L826】【F:app/globals.css†L1410-L1421】
+- The public header now preserves logo and role-aware nav rendering while removing the visible login/role debug line. 【F:components/layout/SiteHeader.tsx†L13-L27】
+- `/search` canonical generation now uses normalized filters, includes valid `q`, `category`, `tag`, and price values, and omits `sort=newest` while preserving valid non-default sorts. 【F:app/(store)/search/page.tsx†L56-L83】
+- `/search` metadata uses the normalized canonical builder while preserving the existing noindex/follow behavior for search-parameter pages. 【F:app/(store)/search/page.tsx†L116-L123】
+- No scope drift found in the reviewed implementation: changed code is aligned to Options A/B/C, and no ProductCard, realtime chat backend, AWS/infrastructure, FAQ/HowTo content, or authorization changes were observed in the reviewed diff.
+- ✅ `npm run lint`
+- ✅ `npm run build`
+- ✅ `npm start`
+- ✅ Python `urllib.request` HTTP probe against `/`, `/search?priceMin=-1`, `/search?priceMax=abc`, `/search?sort=invalid`, `/search?priceMin=3000&sort=price_asc`, and `/search?sort=newest` confirmed one home `h1`, no header login/role noise, presence of the search section marker, and expected canonical normalization.
+
+4. **Human-review readiness: Ready with caveats**
+
+- Ready for human review of the accepted visual/layout direction, with caveats:
+  - Add a native form fallback for `/search` submission to close the progressive-enhancement gap.
+  - Capture desktop/mobile screenshots before relying on human review for final visual spacing and density assessment.


### PR DESCRIPTION
### Motivation

- Address the human-review feedback that the top of the home page is visually overloaded by mixing brand/title, description, search, and navigation in a single card. 
- Reduce demo/debug noise in the public header to improve perceived polish and shopper trust. 
- Fix a low-risk SEO/AEO inconsistency where `/search` canonical URLs reflected raw/invalid query params instead of normalized filters.

### Description

- Separate the home hero and search: keep the hero focused on brand label, a single `h1`, and concise copy, and move `HomeKeywordSearchBar` into a new labeled section (`.home-search-section`) immediately below the hero with `aria-labelledby` (files changed: `app/page.tsx`, `app/globals.css`).
- Improve search behavior and progressive enhancement: update `HomeKeywordSearchBar` to perform client navigation to `/search?q=...` and add native form fallback attributes `action="/search" method="get"` so no-JS submissions reach the search page (file changed: `components/search/HomeKeywordSearchBar.tsx`).
- Reduce header noise: remove the always-visible "ログイン中 / 権限" debug-style line while preserving role-aware navigation (file changed: `components/layout/SiteHeader.tsx`).
- Normalize search canonical generation: build canonical URLs from parsed/normalized `ProductSearchFilters`, omit invalid `priceMin`/`priceMax` and invalid/default `sort=newest` from canonical output (file changed: `app/(store)/search/page.tsx`).
- Save the flow artifacts produced by the custom subagents into `docs/ai/output/.../002-*.md` for proposal, decision, implementation, quality review, and product review packaging.

### Testing

- Ran `npm run lint` and it passed with no ESLint warnings or errors.
- Ran `npm run build`; the implementer and quality-review steps reported a successful build earlier, but a clean rebuild after removing `.next` failed due to an unrelated existing `/og/product` edge-runtime page/module issue, so a fully clean build currently reports a failure not caused by the home/header changes.
- Started the app and performed HTTP checks: `npm start` and Python `urllib.request` probes were used to confirm the presence of the new search section and that canonical URLs for `/search` omit invalid/default params as expected (checks succeeded).
- Attempted automated screenshots with Playwright but the environment blocked fetching Playwright from the registry (`403 Forbidden`), so visual screenshots were not produced; manual desktop/mobile screenshot verification is recommended during human product review.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a7f2562a88328ba42e67e09e1e71c)